### PR TITLE
Reject non-finite validation scores during selection

### DIFF
--- a/src/relarena/runner.py
+++ b/src/relarena/runner.py
@@ -9,6 +9,7 @@ orchestration is out of scope.
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Type
@@ -30,9 +31,15 @@ logger = logging.getLogger(__name__)
 
 def select_best(trials: list[TrialResult], metric: Callable[..., float]) -> TrialResult:
     """Pick the trial with the best validation score under `metric`'s direction."""
-    valid = [t for t in trials if t.ok and t.val_score is not None]
+    valid = [
+        t
+        for t in trials
+        if t.ok and t.val_score is not None and math.isfinite(t.val_score)
+    ]
     if not valid:
-        raise RuntimeError("No successful trials to select from.")
+        raise RuntimeError(
+            "No successful trials with a finite validation score to select from."
+        )
     best = valid[0]
     for t in valid[1:]:
         if is_better(t.val_score, best.val_score, metric):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,12 +5,14 @@ The download, splits, and tuner are stubbed so nothing hits RelBench.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from relbench.base import TaskType
+from relbench.metrics import roc_auc
 
 from relarena import runner
 from relarena.cache import CacheConfig
@@ -23,14 +25,39 @@ _MODEL = SimpleNamespace(
 _IDENTITY = RunIdentity("rel-f1", "db", "driver-dnf", "task")
 
 
-def _trial(tag: str, error: str | None = None) -> TrialResult:
+def _trial(
+    tag: str, error: str | None = None, *, val_score: float = 0.9
+) -> TrialResult:
     return TrialResult(
         config={"tag": tag},
         config_id=tag,
         config_tag=tag,
-        val_score=None if error else 0.9,
+        val_score=None if error else val_score,
         error=error,
     )
+
+
+@pytest.mark.parametrize("nonfinite_score", [math.nan, math.inf, -math.inf])
+def test__select_best__nonfinite_incumbent__selects_finite_trial(
+    nonfinite_score: float,
+) -> None:
+    trials = [
+        _trial("nonfinite", val_score=nonfinite_score),
+        _trial("finite", val_score=0.8),
+    ]
+
+    assert runner.select_best(trials, roc_auc).config_tag == "finite"
+
+
+def test__select_best__only_nonfinite_scores__raises() -> None:
+    trials = [
+        _trial("nan", val_score=math.nan),
+        _trial("positive-infinity", val_score=math.inf),
+        _trial("negative-infinity", val_score=-math.inf),
+    ]
+
+    with pytest.raises(RuntimeError, match="finite validation score"):
+        runner.select_best(trials, roc_auc)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- exclude `NaN`, positive infinity, and negative infinity from validation-score model selection
- raise a clear error when no successful trial has a finite validation score
- add regression coverage for a non-finite first incumbent followed by a finite trial, and for an all-non-finite sweep

This addresses the Bugbot finding on #1 and is stacked directly on that extraction PR.

## Checked-in results audit

`baseline_results/results.csv` contains 1,413 rows across 210 model/dataset/task/seed runs. It has:

- 0 failed rows
- 0 non-finite validation scores
- 0 selected configurations that differ from a fresh finite-score argbest

Therefore none of the checked-in results were affected by this bug. The same check on `baseline_results/experiment_results.csv` found no successful non-finite validation scores.

## Validation

- `OMP_NUM_THREADS=1 pytest`: 396 passed, 10 skipped
- `pre-commit run --all-files`: passed