### PR TITLE
Scope in-process preprocessing caches to their database

### DIFF
--- a/src/relarena/featurization/dfs.py
+++ b/src/relarena/featurization/dfs.py
@@ -379,9 +379,10 @@ class _DepthCache:
       * the full `max_depth` feature matrix per (split dataframe, variant).
 
     Scoped to a single db by *identity* (`is`, holding the db reference so an
-    object-id reuse after GC can't cause a false hit); resets when a new db
-    appears. History variants hold a reference to their history frame for the
-    same reason; split frames are kept alive by the harness.
+    object-id reuse after GC can't cause a false hit); every entry point calls
+    `_scope`, which drops all memos when a new db appears. History variants hold a
+    reference to their history frame for the same reason; split frames are kept
+    alive by the harness.
 
     Implementation notes:
       * `compute` / `build` callables are *thunks*: the cache invokes them
@@ -409,14 +410,31 @@ class _DepthCache:
     def _history_key(history: pd.DataFrame | None) -> int | None:
         return None if history is None else id(history)
 
+    def _scope(self, db: Database) -> None:
+        """Drop every memo when a new db comes into scope.
+
+        Every public entry point scopes first. Eviction must not hang off
+        `raw_rdb_for` alone: with a warm on-disk cache neither the matrix nor the
+        depth map ever builds an RDB (`build_dfs_features` constructs it lazily),
+        so that path is never reached — leaving the previous db's memos to
+        accumulate *and* to be served to the next db.
+
+        Scoping is by identity (`is`), holding the db reference so an address
+        reused after GC can't cause a false hit.
+        """
+        if self._db is db:
+            return
+        self._db = db
+        self._raw_rdb = None
+        self._rdbs = {}
+        self._depth_maps = {}
+        self._matrices = {}
+
     def raw_rdb_for(self, db: Database) -> "RDB":
         """The untransformed RDB for `db` (resets the cache on a new db)."""
-        if self._db is not db:
-            self._db = db
+        self._scope(db)
+        if self._raw_rdb is None:
             self._raw_rdb = _build_rdb(db)
-            self._rdbs = {}
-            self._depth_maps = {}
-            self._matrices = {}
         return self._raw_rdb
 
     def rdb_variant(
@@ -446,12 +464,14 @@ class _DepthCache:
         cache: CacheConfig,
         compute: Callable[[], pd.DataFrame],
     ) -> pd.DataFrame:
-        # Database identity distinguishes protocol states even when disk hits avoid
-        # constructing an RDB and both states share the same task-table objects.
-        # The remaining identities preserve fast reuse across config instances,
-        # while max_depth and the explicit config prevent a scratch computation
-        # from hiding a later fill or a shallow matrix satisfying a deeper request.
-        key = (db, id(source_df), self._history_key(history), max_depth, cache)
+        """The `max_depth` matrix for `(db, source_df, history)`; builds on a miss."""
+        # `_scope` bounds this to the current db, so the key covers only what varies
+        # within one: the split frame and history identities preserve fast reuse
+        # across config instances, while max_depth and the explicit config prevent a
+        # scratch computation from hiding a later fill, or a shallow matrix from
+        # satisfying a deeper request.
+        self._scope(db)
+        key = (id(source_df), self._history_key(history), max_depth, cache)
         if key not in self._matrices:
             self.matrix_computations += 1
             self._matrices[key] = compute()
@@ -459,11 +479,19 @@ class _DepthCache:
 
     def depth_map(
         self,
+        db: Database,
         history: pd.DataFrame | None,
         max_depth: int,
         cache: CacheConfig,
         compute: Callable[[], dict[str, int]],
     ) -> dict[str, int]:
+        """The `{feature: depth}` map for `(db, history)`; `compute` on a miss.
+
+        `db` scopes the memo: the map is keyed by feature *name*, so another
+        database's map matches nothing and the depth filter in
+        `build_dfs_features` would then keep every column.
+        """
+        self._scope(db)
         key = (self._history_key(history), max_depth, cache)
         if key not in self._depth_maps:
             self._depth_maps[key] = compute()
@@ -613,7 +641,7 @@ def build_dfs_features(
         matrix = _CACHE.full_matrix(
             db, source_df, history_key_df, max_depth, cache, _matrix
         )
-        depth_map = _CACHE.depth_map(history_key_df, max_depth, cache, _depth_map)
+        depth_map = _CACHE.depth_map(db, history_key_df, max_depth, cache, _depth_map)
 
     if depth >= max_depth:
         sliced = matrix

--- a/src/relarena/featurization/dfs.py
+++ b/src/relarena/featurization/dfs.py
@@ -401,8 +401,10 @@ class _DepthCache:
         #: history-frame key -> (history frame ref, transformed RDB variant)
         self._rdbs: dict[int | None, tuple[pd.DataFrame | None, "RDB"]] = {}
         self._depth_maps: dict[tuple[int | None, int, CacheConfig], dict[str, int]] = {}
+        #: (id(split frame), history key, max_depth, cache) -> matrix. Scoped to
+        #: the current db by `_scope`, so the db is not part of the key.
         self._matrices: dict[
-            tuple[Database, int, int | None, int, CacheConfig], pd.DataFrame
+            tuple[int, int | None, int, CacheConfig], pd.DataFrame
         ] = {}
         self.matrix_computations = 0  # instrumentation: # of max_depth DFS runs
 

--- a/src/relarena/models/_shared/gnn/graph_cache.py
+++ b/src/relarena/models/_shared/gnn/graph_cache.py
@@ -9,6 +9,9 @@ rebuilds only when the database changes (e.g. the inner->outer split). Holding o
 database's graph at a time is what keeps a config sweep's host-memory footprint flat
 instead of growing with every reloaded graph.
 
+The memoized database is held by reference alongside its `id()`, so a released
+database cannot free its address for a later one to reuse and hit the stale entry.
+
 Dependency-free on purpose (only `typing`): GNN models import it at module level
 while keeping their heavy deps (PyG, torch_frame) lazy, so model registration still
 works without the optional extras installed.
@@ -29,6 +32,7 @@ class DBGraphCache:
         """Start empty."""
         self._key: tuple[int, object | None] | None = None
         self._value: tuple[Any, dict[str, Any]] | None = None
+        self._db: Database | None = None
 
     def get(
         self,
@@ -42,4 +46,11 @@ class DBGraphCache:
         if key != self._key or self._value is None:
             self._value = build()
             self._key = key
+            # Hold the database itself, not just its `id()`: a released database
+            # frees its address for the next same-sized allocation, and the next
+            # censored database landing there would be a false hit -- serving the
+            # inner split's val-censored graph to the outer split's final fit.
+            # Keeping the reference makes that reuse impossible. Only the current
+            # entry is held, so the footprint stays one graph at a time.
+            self._db = db
         return self._value

--- a/tests/featurization/test_dfs.py
+++ b/tests/featurization/test_dfs.py
@@ -86,10 +86,10 @@ def test_depth_cache_memoizes_matrix_and_depth_map(
         dm_calls["n"] += 1
         return {"drivers.COUNT(x)": 2}
 
-    cache.depth_map(None, 2, config, depths)
-    cache.depth_map(None, 2, config, depths)
+    cache.depth_map(db, None, 2, config, depths)
+    cache.depth_map(db, None, 2, config, depths)
     assert dm_calls["n"] == 1
-    cache.depth_map(hist, 2, config, depths)
+    cache.depth_map(db, hist, 2, config, depths)
     assert dm_calls["n"] == 2
 
 
@@ -133,10 +133,10 @@ def test__depth_cache__different_policy__does_not_hide_a_fill(tmp_path: Path) ->
     fill_config = CacheConfig(tmp_path, "fill")
     computed = cache.full_matrix(db, source, None, 2, compute_config, matrix)
     assert computed["f"].tolist() == [1]
-    assert cache.depth_map(None, 2, compute_config, depths) == {"f": 1}
+    assert cache.depth_map(db, None, 2, compute_config, depths) == {"f": 1}
     filled = cache.full_matrix(db, source, None, 2, fill_config, matrix)
     assert filled["f"].tolist() == [2]
-    assert cache.depth_map(None, 2, fill_config, depths) == {"f": 2}
+    assert cache.depth_map(db, None, 2, fill_config, depths) == {"f": 2}
 
 
 def test__depth_cache__different_db_without_rdb_build__does_not_reuse_matrix() -> None:
@@ -171,23 +171,46 @@ def test__depth_cache__different_db_without_rdb_build__does_not_reuse_matrix() -
 def test_depth_cache_resets_on_new_db(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dfs_mod, "_build_rdb", lambda db: f"rdb::{id(db)}")
     cache = _DepthCache()
-    cache.raw_rdb_for(object())
+    db = object()
+    cache.raw_rdb_for(db)
     config = CacheConfig(None, "compute")
     cache.full_matrix(
-        object(),
+        db,
         pd.DataFrame({"a": [1]}),
         None,
         2,
         config,
         lambda: pd.DataFrame({"f": [1]}),
     )
-    cache.depth_map(None, 2, config, lambda: {"f": 2})
+    cache.depth_map(db, None, 2, config, lambda: {"f": 2})
     assert cache._matrices and cache._depth_maps
 
     cache.raw_rdb_for(object())  # different db -> reset
     assert cache._matrices == {}
     assert cache._depth_maps == {}
     assert cache._rdbs == {}
+
+
+def test_depth_cache_scopes_memos_per_db_without_building_an_rdb() -> None:
+    """A warm disk cache builds no RDB, so scoping can't hang off `raw_rdb_for`.
+
+    Depth maps are keyed by feature *name*: another db's map matches nothing, so
+    the slice in `build_dfs_features` would keep every column. Stale matrices
+    would also accumulate for the process lifetime.
+    """
+    cache = _DepthCache()
+    config = CacheConfig(None, "compute")
+    db_a, db_b = object(), object()
+    source = pd.DataFrame({"a": [1]})
+
+    cache.full_matrix(db_a, source, None, 2, config, lambda: pd.DataFrame({"f": [1]}))
+    users = cache.depth_map(db_a, None, 2, config, lambda: {"users.COUNT(reviews)": 2})
+    cache.full_matrix(db_b, source, None, 2, config, lambda: pd.DataFrame({"f": [2]}))
+    shops = cache.depth_map(db_b, None, 2, config, lambda: {"shops.COUNT(sales)": 2})
+
+    assert users == {"users.COUNT(reviews)": 2}
+    assert shops == {"shops.COUNT(sales)": 2}
+    assert len(cache._matrices) == 1  # db_a's evicted, not accumulated
 
 
 # -- temporal diff (pure-pandas; no fastdfs needed) ---------------------------

--- a/tests/featurization/test_dfs.py
+++ b/tests/featurization/test_dfs.py
@@ -279,6 +279,52 @@ def _label_table(
     )
 
 
+#: Renames `_toy_db` onto a disjoint namespace, so the two schemas produce DFS
+#: feature names that cannot overlap.
+_RENAME = {
+    "users": "shops",
+    "reviews": "sales",
+    "uid": "sid",
+    "age": "size",
+    "rating": "amount",
+}
+
+
+def _other_db() -> Database:
+    """`_toy_db`'s structure under disjoint table and column names."""
+    return Database(
+        {
+            _RENAME[name]: Table(
+                df=t.df.rename(columns=_RENAME),
+                fkey_col_to_pkey_table={
+                    _RENAME[c]: _RENAME[p] for c, p in t.fkey_col_to_pkey_table.items()
+                },
+                pkey_col=_RENAME[t.pkey_col] if t.pkey_col else None,
+                time_col=t.time_col,
+            )
+            for name, t in _toy_db().table_dict.items()
+        }
+    )
+
+
+def _other_task() -> SimpleNamespace:
+    """An entity task over `shops` (matches `_other_db`)."""
+    return SimpleNamespace(
+        entity_table="shops", entity_col="sid", target_col="y", time_col="ts"
+    )
+
+
+def _other_label_table(uids: list[int]) -> Table:
+    """`_label_table` renamed onto `_other_db`."""
+    t = _label_table(uids)
+    return Table(
+        df=t.df.rename(columns=_RENAME),
+        fkey_col_to_pkey_table={"sid": "shops"},
+        pkey_col=None,
+        time_col="ts",
+    )
+
+
 def test__dfs_cache_key__tracks_inputs_not_downstream_model_choices() -> None:
     db, task = _toy_db(), _toy_task()
     anchors = _label_table([1, 2], y=[0.0, 1.0])
@@ -594,6 +640,48 @@ def test__build_dfs_features__cache_persists_across_processes(
     )
     assert calls["n"] == 1  # served from disk, DFS not re-run
     pd.testing.assert_frame_equal(second, first)
+
+
+def test__build_dfs_features__warm_cache_second_task__slices_to_its_own_depth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The documented sweep shape: warm the shared cache, then run many tasks in one
+    # process (the CLI loops over every task in-process). Everything below is the
+    # real path -- real DFS engine, real parquet cache, real depth slice; only the
+    # process-level _CACHE is swapped, to stand in for a fresh worker.
+    pytest.importorskip("fastdfs")
+    a = (
+        _toy_task(),
+        _toy_db(),
+        _label_table([1, 2, 3]),
+        RunIdentity("a", "fa", "ta", "x"),
+    )
+    b = (
+        _other_task(),
+        _other_db(),
+        _other_label_table([1, 2, 3]),
+        RunIdentity("b", "fb", "tb", "x"),
+    )
+
+    def build(spec: tuple, cache: CacheConfig) -> pd.DataFrame:
+        task, db, tbl, ident = spec
+        features, _ = dfs_mod.build_dfs_features(
+            task, db, tbl, depth=1, max_depth=2, cache=cache, run_identity=ident
+        )
+        return features
+
+    for spec in (a, b):  # warm the shared cache, as the feature warmer does
+        build(spec, CacheConfig(tmp_path, "fill"))
+    read = CacheConfig(tmp_path, "raise")  # every artifact must now be a disk hit
+
+    monkeypatch.setattr(dfs_mod, "_CACHE", _DepthCache())
+    solo = build(b, read)  # task B alone
+
+    monkeypatch.setattr(dfs_mod, "_CACHE", _DepthCache())
+    build(a, read)  # task A first, leaving its depth map in the process cache
+    after = build(b, read)
+
+    pd.testing.assert_frame_equal(after, solo)
 
 
 def test__build_dfs_features__cache_key_discriminates_depth_and_history(

--- a/tests/models/_shared/gnn/test_graph_cache.py
+++ b/tests/models/_shared/gnn/test_graph_cache.py
@@ -3,6 +3,10 @@
 from relarena.models._shared.gnn.graph_cache import DBGraphCache
 
 
+class _DB:
+    """Stand-in for a relbench `Database` (same-size objects reuse addresses)."""
+
+
 def test__get__same_db__builds_once_and_reuses() -> None:
     """Repeated get() for one db builds once and returns the same memoized object."""
     cache = DBGraphCache()
@@ -50,3 +54,16 @@ def test__get__same_db_different_variant__rebuilds() -> None:
     cache.get(db, build, variant="compute")
     cache.get(db, build, variant="fill")
     assert calls == [1, 1]
+
+
+def test__get__db_released_then_new_db__never_serves_the_stale_graph() -> None:
+    """A released db's address, reused by the next one, must not be a false hit.
+
+    Mirrors `run_experiment`: the inner split's db goes unreferenced when `tune`
+    returns, then the outer split allocates a new one onto the freed address. A
+    hit there would score the final test fit on the val-censored graph.
+    """
+    cache = DBGraphCache()
+    for i in range(100):
+        cache.get(_DB(), lambda: ("inner", {}))  # unreferenced once get() returns
+        assert cache.get(_DB(), lambda: (f"outer-{i}", {}))[0] == f"outer-{i}"


### PR DESCRIPTION
Two module-level caches keyed entries by a database's `id()` in ways that could serve one database's artifact for another. Both fail silently — no exception, no warning, just wrong features or a wrong graph.

## 1. `_DepthCache` — depth map not scoped to the database

`depth_map` keyed on `(history, max_depth, cache)` with no database at all, while its sibling `full_matrix` did include one. Eviction lived only in `raw_rdb_for`, and with a warm on-disk cache neither the matrix nor the depth map ever builds an RDB (`build_dfs_features` constructs it lazily, precisely so a warm cache skips it) — so that reset never fires.

The first task's depth map is then served to every later task in the process. Depth maps are keyed by feature *name*, so nothing matches and the filter in `build_dfs_features` keeps every column:

```
warm cache, task A then task B, one process:
  B depth=1 -> ['shops.size', 'shops.COUNT(sales)', ... 9 columns]   # full max_depth
  B alone   -> ['shops.size']                                        # correct
```

This silently turns the `max_depth` grid that `rdblearn` and `tabpfn-rel` tune over into a no-op for every task after the first, and makes each "depth 2" config actually depth 4.

## 2. `_DepthCache` — unbounded growth

Same root cause. With the reset unreachable, every database's full `max_depth` matrix stayed resident for the process lifetime. Confirmed: after two databases, `_db` was still `None` and `_matrices` held both with nothing evictable.

**Fix for 1 + 2:** both entry points call a new `_scope`, which drops all memos when a new database appears and holds the database reference.

## 3. `DBGraphCache` — `id()` reuse after GC

Stored a bare `id(db)`. A released database frees its address for the next same-sized allocation, so the outer split's database can land on the inner split's address and hit its entry — scoring the final test fit on the **val-censored** graph. Mirrors `run_experiment`, where the inner split goes unreferenced when `tune` returns.

`_DepthCache`'s docstring already called out this exact hazard and guarded against it; this cache didn't. `relgnn` was unaffected (its `variant` carries a content-derived key); `graphsage` and `relgt` pass no variant.

**Fix:** hold the database alongside the key, which makes the reuse impossible. Only the current entry is held, so the footprint stays one graph at a time.

## Effect on the released baselines — one model still open

Provenance is confirmed: the published `results.csv` came from `generate_relarena_baselines.py` (`to_public_frame` maps the job `id` to a device label then drops `id`; the CSV has `device` and no `id`).

**SLURM-launched models are clear of bug #1.** `--functions-per-job` defaults to 1 and no documented launch command overrides it; at 1 each SLURM job runs a single `JobSpec` — one model on one task at one seed — so every `run_experiment` had its own process. The depth-map contamination can only corrupt the 2nd and later tasks in a process.

**`tabpfn-rel-client` is not clear.** Its documented launch uses `--local` ("drive tabpfn-rel-client sequentially in-process"), and `LocalBackend.run` executes each job immediately in the calling process — all 21 tasks, one process. The same command supplies a ready (warm) artifact tree, and `run_experiment` resolves the cache with `on_miss="raise"`, so every DFS artifact is a disk hit and the RDB is never built. That is exactly this bug's trigger. If the release used that command, tasks 2-21 ran every depth config against the full depth-4 matrix: the depth grid was a no-op and the config labels are wrong, though the reported test scores remain valid scores of the depth-4 model.

This cannot be settled from the repo — the `device` column is a mapped label (`cpu`), which does not distinguish `--local` from a SLURM CPU job, and the actual invocations are not recorded here.

**Bug #3** is memory growth only; it cannot change results.

**Bug #2** is independent of process layout — it triggers within a single `run_experiment` (the inner split's database is released when `tune` returns, then the outer split allocates onto the freed address). Measured at ~1/300 per experiment against the runner's real allocation pattern, affecting `graphsage` and `relgt` only.

## Tests

Three added, all failing on `main`:

- `test_depth_cache_scopes_memos_per_db_without_building_an_rdb` — the mechanism, directly on `_DepthCache`, no patching. Covers the wrong map and the accumulation in one.
- `test__build_dfs_features__warm_cache_second_task__slices_to_its_own_depth` — the symptom, through the real path: real DFS engine, real parquet cache, real depth slice. Only the process-level `_CACHE` is swapped, standing in for a fresh worker, as the existing cross-process cache test already does. Pre-fix the second task's depth-1 request returns 10 columns instead of 2.
- `test__get__db_released_then_new_db__never_serves_the_stale_graph` — fails on iteration 0 pre-fix.

Existing `depth_map` call sites updated for the new `db` parameter. Full suite green (397 passed, 11 skipped).

## Not included

`_matrices`/`_depth_maps` still key history frames by `id()` without pinning them — the same class as #3. It's benign today (the only frames in play within a database scope are semantically identical), so it's left out to keep this diff reviewable. Happy to fold it in if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VaWdvUZ2hUFSf53QUZUE9



