### PR TITLE
Add a tag-driven PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,166 @@
+name: Release
+
+# Build once, verify the artifact, then publish that exact artifact.
+#
+#   * push a `v<version>` tag  -> build, verify, publish to PyPI, cut a GitHub release
+#   * run manually             -> build, verify, and publish to TestPyPI (or nothing)
+#
+# Publishing uses PyPI Trusted Publishing (OIDC), so no API token is stored in the
+# repository. See docs/releasing.md for the one-time publisher setup.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish the built distributions"
+        type: choice
+        options: [none, testpypi, pypi]
+        default: none
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and verify distributions
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      # The version lives in two places (pyproject and relarena.__version__) and the
+      # tag is a third. A mismatch is unrecoverable once uploaded — PyPI never lets a
+      # version be reused — so it is a hard gate before anything is built.
+      - name: Check version consistency
+        id: version
+        env:
+          GIT_REF: ${{ github.ref }}
+          IS_TAG: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, pathlib, re, sys, tomllib
+
+          pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          version = pyproject["project"]["version"]
+
+          init = pathlib.Path("src/relarena/__init__.py").read_text()
+          dunder = re.search(r'^__version__ = "(.+)"$', init, re.MULTILINE).group(1)
+          if dunder != version:
+              sys.exit(f"pyproject version {version} != relarena.__version__ {dunder}")
+
+          if os.environ["IS_TAG"] == "true":
+              tag = os.environ["GIT_REF"].removeprefix("refs/tags/")
+              if tag != f"v{version}":
+                  sys.exit(f"tag {tag} does not match project version {version}")
+
+          prerelease = bool(re.search(r"(a|b|rc|\.dev)\d*$", version))
+          print(f"version={version}")
+          print(f"prerelease={str(prerelease).lower()}")
+          PY
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Verify required package data
+        run: python workflows/verify_distributions.py
+
+      - name: Check distribution metadata
+        run: uvx twine check --strict dist/*
+
+      # Install the built wheel into a throwaway environment and exercise the import
+      # surface the docs and cookbook rely on. This is what catches a release that
+      # builds cleanly but ships a package missing the API users are told to call.
+      # Run from RUNNER_TEMP so the project's own [tool.uv] settings do not apply.
+      - name: Smoke-test the wheel
+        env:
+          UV_TORCH_BACKEND: cpu
+        run: |
+          cd "$RUNNER_TEMP"
+          uv venv smoke --python 3.11
+          uv pip install --python smoke "$GITHUB_WORKSPACE"/dist/*.whl
+          smoke/bin/python - <<'PY'
+          import relarena
+          from relarena.userdb import PredictiveQuery
+
+          print("relarena", relarena.__version__)
+          for name in relarena.__all__:
+              getattr(relarena, name)
+          assert hasattr(PredictiveQuery, "compute_test_labels")
+          PY
+          smoke/bin/relarena --help > /dev/null
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/relarena/${{ needs.build.outputs.version }}
+    permissions:
+      id-token: write # trusted publishing
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distributions
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/relarena/${{ needs.build.outputs.version }}
+    permissions:
+      id-token: write # trusted publishing
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distributions
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+
+  github-release:
+    name: Cut the GitHub release
+    needs: [build, publish-pypi]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distributions
+          path: dist/
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          prerelease: ${{ needs.build.outputs.prerelease == 'true' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,5 @@ live in `baseline_results/SOURCES.md`.
   nested temporal-validation protocol and why the inner/outer splits exist.
 - [docs/predictive-task.md](docs/predictive-task.md) — defining a predictive
   task over your own relational database.
+- [docs/releasing.md](docs/releasing.md) — cutting a PyPI release (tag-driven,
+  trusted publishing) and what the release workflow verifies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,9 @@ OMP_NUM_THREADS=1 uv run pytest
 uv build
 ```
 
+Releases to PyPI are cut by pushing a `v<version>` tag; the procedure and the
+one-time publisher setup are in [docs/releasing.md](docs/releasing.md).
+
 For model integrations, follow [docs/adding-a-model.md](docs/adding-a-model.md).
 Keep optional dependencies lazy, document provenance for adapted or vendored
 code, and include focused tests. By contributing, you agree that your changes

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,120 @@
+# Releasing RelArena to PyPI
+
+Releases are cut by [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+Pushing a `v<version>` tag builds the distributions, verifies them, publishes to
+PyPI, and cuts a GitHub release with the same artifacts attached. Nothing is
+published from a laptop, and no PyPI API token is stored in the repository —
+uploads authenticate with [Trusted
+Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), so only this
+workflow, in this repository, can publish `relarena`.
+
+## One-time setup
+
+Someone with owner rights on the PyPI project does this once; it does not need
+repeating per release.
+
+1. **PyPI** → the `relarena` project → *Publishing* → add a GitHub publisher:
+
+   | Field | Value |
+   | --- | --- |
+   | Owner | `PriorLabs` |
+   | Repository | `relarena` |
+   | Workflow | `release.yml` |
+   | Environment | `pypi` |
+
+2. **TestPyPI** → same form at <https://test.pypi.org/manage/account/publishing/>,
+   with environment `testpypi`. (TestPyPI is a separate account and a separate
+   project registration.)
+
+3. **GitHub** → *Settings* → *Environments* → create `pypi` and `testpypi`. Add
+   required reviewers on `pypi` if a release should need a second pair of eyes;
+   the workflow then pauses before the upload step until someone approves.
+
+The environment names must match on both sides — a mismatch fails at the upload
+step with `invalid-publisher`, after the build has already succeeded.
+
+## Cutting a release
+
+1. Bump the version in the two places that carry it, plus the lock file:
+
+   ```bash
+   # pyproject.toml   -> [project] version
+   # src/relarena/__init__.py -> __version__
+   uv lock            # refreshes the relarena entry in uv.lock
+   ```
+
+   The workflow refuses to build if those two versions disagree, or if the tag
+   does not equal `v<version>`. PyPI never allows a version to be re-uploaded,
+   so this is checked before anything is built rather than after.
+
+   Version strings follow [PEP 440](https://peps.python.org/pep-0440/): `0.1.0`,
+   `0.1.0a1`, `0.1.0rc1`. Anything ending in `a`/`b`/`rc`/`.dev` is marked as a
+   prerelease on the GitHub release and is not installed by a bare
+   `pip install relarena`.
+
+2. Merge the bump to `main` and let CI pass.
+
+3. Tag and push:
+
+   ```bash
+   git tag v0.1.0a3 -m "relarena 0.1.0a3"
+   git push origin v0.1.0a3
+   ```
+
+4. Watch the run. On success the package is live at
+   <https://pypi.org/project/relarena/> and a GitHub release is drafted from the
+   commits since the previous tag.
+
+## Dry runs
+
+`workflow_dispatch` (the *Run workflow* button) takes a `target` input:
+
+- `none` — build and run every verification, publish nothing. Use this to check
+  a release candidate before tagging.
+- `testpypi` — same, then upload to TestPyPI. Useful for rehearsing the install
+  path end to end:
+
+  ```bash
+  pip install --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ relarena
+  ```
+
+  The extra index is required because TestPyPI does not mirror `relarena`'s
+  dependencies.
+- `pypi` — publish the current branch's version to PyPI without a tag. Prefer
+  tagging; this exists for recovery when a tag push failed after the tag was
+  already consumed.
+
+## What the release gates on
+
+Beyond the version check, the build job runs three verifications before anything
+can be published:
+
+- `workflows/verify_distributions.py` — the wheel and sdist both carry the
+  package data the harness needs at runtime (vendored licenses, dataset
+  checksums, userdb JSON schemas and task YAML).
+- `twine check --strict` — the rendered README and metadata are valid, so the
+  PyPI project page does not land broken.
+- A smoke install of the built wheel into a clean environment, which imports
+  every name in `relarena.__all__` and runs `relarena --help`. This is the check
+  that catches a release which builds fine but ships an API older than the docs
+  describe — the failure mode behind the `0.0.1a1` alpha, where the cookbook
+  called `PredictiveQuery.compute_test_labels` and the published package did not
+  have it.
+
+## Known limitation: the `leaderboard` and `plots` extras
+
+Both extras depend on `bencheval`, which is **not published on PyPI** — this
+repository resolves it from the TabArena git repository via
+`[tool.uv.sources]`. That source is a local resolution hint and is not recorded
+in the published metadata, so
+
+```bash
+pip install "relarena[leaderboard]"   # fails: No matching distribution for bencheval
+```
+
+fails for anyone installing from PyPI. Leaderboard aggregation and plots
+currently work only from a git checkout with `uv sync`, which the README's
+Installation section states. Nothing in the release workflow can fix this —
+it needs `bencheval` on PyPI, or the extras vendored differently. Keep the
+README caveat in step with reality until then.


### PR DESCRIPTION
## Why

Releasing is manual today, and it shows: PyPI is still on `0.0.1a1` while the repo is on `0.0.1a2`, so the cookbook calls `PredictiveQuery.compute_test_labels` and the published package doesn't have it.

## What

`.github/workflows/release.yml`:

- **Push a `v<version>` tag** → build once, verify, publish to PyPI, cut a GitHub release with the same artifacts attached.
- **Run manually** (`workflow_dispatch`) → the identical build and verification against `none` (dry run) or `testpypi`.
- Uploads use [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) through the `pypi` / `testpypi` GitHub environments — no PyPI token in the repo, and only this workflow in this repo can publish `relarena`. Put required reviewers on the `pypi` environment if a release should need approval.

Gates that run before anything can be uploaded:

| Gate | Catches |
| --- | --- |
| version consistency (`pyproject` ↔ `relarena.__version__` ↔ tag) | a bad version number, *before* the build — PyPI never allows a re-upload |
| `workflows/verify_distributions.py` | missing package data (licenses, checksums, userdb schemas/YAML) |
| `twine check --strict` | a broken PyPI project page |
| smoke install of the built wheel in a clean env | exactly the `0.0.1a1` failure — imports every name in `relarena.__all__`, checks `PredictiveQuery.compute_test_labels`, runs `relarena --help` |

`docs/releasing.md` documents the one-time publisher setup, the release procedure, and the dry-run path; linked from `CONTRIBUTING.md` and `AGENTS.md`.

## Also flagged in the docs

`leaderboard` and `plots` both depend on `bencheval`, which is **not on PyPI** — it resolves from the TabArena git repo via `[tool.uv.sources]`, which is a local hint and is not carried into published metadata. So `pip install "relarena[leaderboard]"` fails for anyone installing from PyPI. Not fixed here; recorded in `docs/releasing.md` so it doesn't get discovered by a user first.

## Verification

Every step except the upload itself was run locally against the current tree: `uv build`, `verify_distributions.py`, `twine check --strict` (both dists PASSED), and the wheel smoke install into a clean 3.11 venv (imports + `relarena --help` OK). The version-check script was exercised for a matching tag, a mismatched tag (fails as intended), a manual dispatch, and prerelease detection across PEP 440 forms.

## Before the first tagged release

1. Register the trusted publishers on PyPI and TestPyPI (`docs/releasing.md` has the exact fields).
2. Create the `pypi` and `testpypi` GitHub environments.
3. Run the workflow manually with `target: none`, then `testpypi`, to rehearse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)