### PR TITLE
Link the model report on arXiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-| 📂 [Examples](examples) | 📊 [Baseline Results](baseline_results) | 🧩 [Add a Model](docs/adding-a-model.md) | 🗄️ [Your Own Database](docs/predictive-task.md) | 📄 Model report: *in preparation* |
+| 📂 [Examples](examples) | 📊 [Baseline Results](baseline_results) | 🧩 [Add a Model](docs/adding-a-model.md) | 🗄️ [Your Own Database](docs/predictive-task.md) | 📄 [Model Report](https://arxiv.org/abs/2608.16319) |
 |:---:|:---:|:---:|:---:|:---:|
 
 ---
@@ -44,8 +44,8 @@ tabular benchmarks such as [TabArena](https://tabarena.ai). This repository also
 > **Current status: α-release**, targeted at researchers and early-adopting practitioners. This
 > release focuses on RelBench v1's entity-level forecasting tasks, and its task coverage,
 > baselines, API, and tuning regime will evolve with community feedback. Research code, not
-> production-ready. A detailed model report covering RelArena-α, TabPFN-Rel, and the RPI is in
-> preparation.
+> production-ready. The model report covering RelArena-α, TabPFN-Rel, and the RPI is available
+> at [arXiv:2608.16319](https://arxiv.org/abs/2608.16319).
 
 ## ⚡ Quickstart
 
@@ -598,23 +598,27 @@ See [`docs/licensing.md`](docs/licensing.md) for what the license does and does 
 
 ## 📄 Citation
 
-The model report covering RelArena-α, TabPFN-Rel, and the RPI is **in preparation**; this section
-will carry its link and final entry once it is out. Until then, cite it as:
+The model report covering RelArena-α, TabPFN-Rel, and the RPI is on arXiv as
+[arXiv:2608.16319](https://arxiv.org/abs/2608.16319). If you use RelArena-α, TabPFN-Rel, or the
+RPI, please cite:
 
 > **Advancing Open and Reproducible Relational Learning: RelArena-α, TabPFN-Rel and RPI**
 > Adrian Hayler, Klemens Flöge, Alan Arazi, Rishabh Ranjan, Jure Leskovec, Lennart Purucker,
-> Frank Hutter, Noah Hollmann, and the Prior Labs Team. Prior Labs, 2026.
+> Frank Hutter, Noah Hollmann, and the Prior Labs Team. arXiv:2608.16319, 2026.
 
 ```bibtex
-@techreport{relarena2026,
-  title       = {Advancing Open and Reproducible Relational Learning: {RelArena}-$\alpha$,
-                 {TabPFN}-Rel and {RPI}},
-  author      = {Hayler, Adrian and Fl{\"o}ge, Klemens and Arazi, Alan and Ranjan, Rishabh and
-                 Leskovec, Jure and Purucker, Lennart and Hutter, Frank and Hollmann, Noah and
-                 {the Prior Labs Team}},
-  institution = {Prior Labs},
-  year        = {2026},
-  url         = {https://github.com/PriorLabs/relarena}
+@article{relarena2026,
+  title         = {Advancing Open and Reproducible Relational Learning: {RelArena}-$\alpha$,
+                   {TabPFN}-Rel and {RPI}},
+  author        = {Hayler, Adrian and Fl{\"o}ge, Klemens and Arazi, Alan and Ranjan, Rishabh and
+                   Leskovec, Jure and Purucker, Lennart and Hutter, Frank and Hollmann, Noah and
+                   {the Prior Labs Team}},
+  journal       = {arXiv preprint arXiv:2608.16319},
+  year          = {2026},
+  eprint        = {2608.16319},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.LG},
+  url           = {https://arxiv.org/abs/2608.16319}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
 Homepage = "https://github.com/PriorLabs/relarena"
 Repository = "https://github.com/PriorLabs/relarena"
 Issues = "https://github.com/PriorLabs/relarena/issues"
+Paper = "https://arxiv.org/abs/2608.16319"
 
 [project.scripts]
 relarena = "relarena.cli:main"


### PR DESCRIPTION
The model report is published as [arXiv:2608.16319](https://arxiv.org/abs/2608.16319) ("Advancing Open and Reproducible Relational Learning: RelArena-α, TabPFN-Rel and RPI", submitted 2026-08-17), but nothing in this repository referenced it — three places still said the report was in preparation. Part of [RES-2570](https://linear.app/priorlabs/issue/RES-2570/add-cross-links).

- **Header nav cell** — `📄 Model report: *in preparation*` becomes a `📄 [Model Report]` link, matching the other four cells.
- **α-release note** — now says the report is available at arXiv:2608.16319.
- **Citation section** — links the paper, and the BibTeX becomes an `@article` with `eprint` / `archivePrefix` / `primaryClass = {cs.LG}` and the arXiv URL, instead of a `@techreport` whose `url` pointed back at this repository.
- **`pyproject.toml`** — adds `Paper` to `[project.urls]`, so the arXiv link shows up in the PyPI sidebar.

Docs-only; no code paths touched.

Two related gaps outside this repo, not addressed here: the GitHub repo homepage field is still empty (settable directly, not via a PR), and `PriorLabs/tabpfn-cookbook` has no relational content to cross-link from yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvYFvfRHGEgBBvhNgRVbHD