### PR TITLE
Key the DFS depth map by the engine's column name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ lightgbm = ["lightgbm>=4.0,<4.7"]
 # plus the DFS featurization deps; `tabpfn-rel-local` uses this same extra.
 # setuptools<82 because featuretools -> woodwork imports pkg_resources at import
 # time, and setuptools 82 removed it (81 still ships it).
-rdblearn = ["tabpfn>=8", "fastdfs>=0.2.1", "setuptools<82"]
+rdblearn = ["tabpfn>=8", "fastdfs>=1.1", "setuptools<82"]
 # rdl: the shared Relational Deep Learning stack for the GNN baselines — PyG + PyTorch
 # Frame + a text embedder, which relbench.modeling.* needs (all lazy-imported inside
 # fit()). GPU recommended. NOTE: PyG neighbor sampling needs `pyg-lib` or `torch-sparse`
@@ -91,7 +91,7 @@ relgt = ["relarena[rdl]", "einops>=0.8", "h5py>=3.0"]
 # tabpfn-rel-client (the tabpfn-v3-api TFM): DFS locally, fit/predict server-side,
 # text embedded natively by the API — no GPU and no local tabpfn needed.
 tabpfn-rel-local = ["relarena[rdblearn]"]
-tabpfn-rel-api = ["fastdfs>=0.2.1", "setuptools<82", "tabpfn-client>=0.3.2"]
+tabpfn-rel-api = ["fastdfs>=1.1", "setuptools<82", "tabpfn-client>=0.3.2"]
 # RelArena supports RT execution on Linux x86_64, for which relational-transformer
 # publishes a stable-ABI (abi3-py311) wheel. GPU strongly recommended -- a
 # fine-tune on CPU is not a practical run.
@@ -112,7 +112,7 @@ dev = [
     "pre-commit>=4.0",
     "ruff==0.15.13",
     "lightgbm>=4.0,<4.7",
-    "fastdfs>=0.2.1",
+    "fastdfs>=1.1",
     # Same woodwork/pkg_resources cap as the DFS extras above.
     "setuptools<82",
 ]

--- a/src/relarena/featurization/dfs.py
+++ b/src/relarena/featurization/dfs.py
@@ -55,8 +55,19 @@ from relarena.featurization._columns import type_columns
 from relarena.featurization.cache import cached_frame
 from relarena.identity import RunIdentity
 
+try:
+    # fastdfs >= 1.1 names matrix columns `d{depth}__{feature}`; the depth map must
+    # use the same names or every lookup misses.
+    from fastdfs.dfs import dfs_feature_column_name as _feature_column_name
+except ImportError:
+
+    def _feature_column_name(feature: "FeatureBase") -> str:
+        return feature.get_name()
+
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from fastdfs import RDB
+    from featuretools import FeatureBase
 
 #: Deepest shared DFS matrix built by the warmer and sliced by model depth grids.
 #: This is part of artifact identity, so models and warmers must not define it
@@ -69,7 +80,7 @@ TARGET_HISTORY_TABLE_NAME = "_RDBL_target_history"
 #: Bumped when DFS-building or the RDB-transform pipeline changes in a way that
 #: should invalidate persisted feature matrices — the disk cache key pins the data
 #: content and build params, not the code that turns one into the other.
-_DFS_CACHE_VERSION = 2
+_DFS_CACHE_VERSION = 3
 
 
 def _source_identity_segments(
@@ -603,7 +614,7 @@ def build_dfs_features(
             # never the cached RDB: the mutation only *adds* a column, so a
             # `copy(deep=False)` (shared column data, no duplication) suffices.
             return {
-                f.get_name(): f.get_depth()
+                _feature_column_name(f): f.get_depth()
                 for f in get_dfs_engine(cfg.engine, cfg).prepare_features(
                     _shallow_frame_copy(_rdb()),
                     _dfs_input(),
@@ -648,6 +659,12 @@ def build_dfs_features(
     if depth >= max_depth:
         sliced = matrix
     else:
+        if not any(c in depth_map for c in matrix.columns):
+            raise RuntimeError(
+                "No DFS matrix column is in the depth map, so the slice would keep "
+                "every column at every depth. The DFS engine and the depth map "
+                "disagree on column naming."
+            )
         keep = [c for c in matrix.columns if depth_map.get(c, -1) <= depth]
         sliced = matrix.loc[:, keep]
 

--- a/src/relarena/featurization/dfs.py
+++ b/src/relarena/featurization/dfs.py
@@ -47,6 +47,10 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Callable
 
 import pandas as pd
+
+# The engine names matrix columns `d{depth}__{feature}`; the depth map must use the
+# same names or every lookup misses.
+from fastdfs.dfs import dfs_feature_column_name
 from relbench.base import Database, EntityTask, Table
 
 from relarena.cache import CacheConfig, cache_key
@@ -55,19 +59,8 @@ from relarena.featurization._columns import type_columns
 from relarena.featurization.cache import cached_frame
 from relarena.identity import RunIdentity
 
-try:
-    # fastdfs >= 1.1 names matrix columns `d{depth}__{feature}`; the depth map must
-    # use the same names or every lookup misses.
-    from fastdfs.dfs import dfs_feature_column_name as _feature_column_name
-except ImportError:
-
-    def _feature_column_name(feature: "FeatureBase") -> str:
-        return feature.get_name()
-
-
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from fastdfs import RDB
-    from featuretools import FeatureBase
 
 #: Deepest shared DFS matrix built by the warmer and sliced by model depth grids.
 #: This is part of artifact identity, so models and warmers must not define it
@@ -614,7 +607,7 @@ def build_dfs_features(
             # never the cached RDB: the mutation only *adds* a column, so a
             # `copy(deep=False)` (shared column data, no duplication) suffices.
             return {
-                _feature_column_name(f): f.get_depth()
+                dfs_feature_column_name(f): f.get_depth()
                 for f in get_dfs_engine(cfg.engine, cfg).prepare_features(
                     _shallow_frame_copy(_rdb()),
                     _dfs_input(),

--- a/tests/featurization/test_dfs.py
+++ b/tests/featurization/test_dfs.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import numpy as np
 import pandas as pd
 import pytest
+from fastdfs.dfs import dfs_feature_column_name
 from relbench.base import Database, Table
 
 import relarena.featurization.dfs as dfs_mod
@@ -16,7 +17,6 @@ from relarena.cache import CacheConfig
 from relarena.featurization.dfs import (
     TARGET_HISTORY_TABLE_NAME,
     _DepthCache,
-    _feature_column_name,
     _temporal_diff,
 )
 from relarena.identity import RunIdentity
@@ -742,17 +742,10 @@ def test__build_dfs_features__leaves_no_engine_db_behind(
     assert list(tmp_path.iterdir()) == []
 
 
-def test__feature_column_name__matches_the_engine_naming() -> None:
+def test__depth_map__keys_match_the_engine_column_naming() -> None:
     """The depth map must key on the name the engine gives the matrix column."""
     feature = SimpleNamespace(
         get_name=lambda: "drivers.COUNT(results)", get_depth=lambda: 2
     )
 
-    name = _feature_column_name(feature)
-
-    try:
-        from fastdfs.dfs import dfs_feature_column_name
-    except ImportError:
-        assert name == "drivers.COUNT(results)"
-    else:
-        assert name == dfs_feature_column_name(feature)
+    assert dfs_feature_column_name(feature) == "d2__drivers.COUNT(results)"

--- a/tests/featurization/test_dfs.py
+++ b/tests/featurization/test_dfs.py
@@ -16,6 +16,7 @@ from relarena.cache import CacheConfig
 from relarena.featurization.dfs import (
     TARGET_HISTORY_TABLE_NAME,
     _DepthCache,
+    _feature_column_name,
     _temporal_diff,
 )
 from relarena.identity import RunIdentity
@@ -739,3 +740,19 @@ def test__build_dfs_features__leaves_no_engine_db_behind(
     )
 
     assert list(tmp_path.iterdir()) == []
+
+
+def test__feature_column_name__matches_the_engine_naming() -> None:
+    """The depth map must key on the name the engine gives the matrix column."""
+    feature = SimpleNamespace(
+        get_name=lambda: "drivers.COUNT(results)", get_depth=lambda: 2
+    )
+
+    name = _feature_column_name(feature)
+
+    try:
+        from fastdfs.dfs import dfs_feature_column_name
+    except ImportError:
+        assert name == "drivers.COUNT(results)"
+    else:
+        assert name == dfs_feature_column_name(feature)

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-08-12T16:57:11.856998Z"
+exclude-newer = "2026-08-17T14:51:09.374820413Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "fastdfs"
-version = "0.2.1"
+version = "1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -570,9 +570,9 @@ dependencies = [
     { name = "sqlglot" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/e2/73d5a6797353d7558737bea695b392ae07d19c1884e55b804a4e3b57d620/fastdfs-0.2.1.tar.gz", hash = "sha256:c5eb768d8644376ae07975340b8e6f009f1c3c7a456a7fc1d5f6b994fd034889", size = 88450, upload-time = "2026-05-18T07:28:19.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/81/4bd3bb20b75f80a9dd5c34608c1596e6d48547a0dc24064c3a9c65989817/fastdfs-1.1.tar.gz", hash = "sha256:c3142b055cf5d37188f6dedc345ad0b25b06757e0db3bdfddda82b0adb5f9c3c", size = 96787, upload-time = "2026-07-13T08:39:20.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/0b/c79f80928a1d58a4a62065e0bc88036cc8d095556ccaf959ff40ed1721f4/fastdfs-0.2.1-py3-none-any.whl", hash = "sha256:e651a3b5db092a11deab0c9f01fe5797425caacb5e312833106e508994b2b0e3", size = 77734, upload-time = "2026-05-18T07:28:18.065Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a9/a292b4d7e5331cc0a019a1d0179ac7033fec7d7de504bf52f249a0a5f1d6/fastdfs-1.1-py3-none-any.whl", hash = "sha256:4ea3b4813431c40f99fa7dec820da604a0a9366e2a0f90a4a119f2c66084fd59", size = 82903, upload-time = "2026-07-13T08:39:18.919Z" },
 ]
 
 [[package]]
@@ -2173,8 +2173,8 @@ requires-dist = [
     { name = "bencheval", extras = ["plot"], marker = "extra == 'plots'", git = "https://github.com/autogluon/tabarena.git?subdirectory=packages%2Fbencheval&rev=9f3878b882439cb885003b5f978676961b059b6d" },
     { name = "configspace", specifier = ">=1.0" },
     { name = "einops", marker = "extra == 'relgt'", specifier = ">=0.8" },
-    { name = "fastdfs", marker = "extra == 'rdblearn'", specifier = ">=0.2.1" },
-    { name = "fastdfs", marker = "extra == 'tabpfn-rel-api'", specifier = ">=0.2.1" },
+    { name = "fastdfs", marker = "extra == 'rdblearn'", specifier = ">=1.1" },
+    { name = "fastdfs", marker = "extra == 'tabpfn-rel-api'", specifier = ">=1.1" },
     { name = "h5py", marker = "extra == 'relgt'", specifier = ">=3.0" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "lightgbm", marker = "extra == 'lightgbm'", specifier = ">=4.0,<4.7" },
@@ -2203,7 +2203,7 @@ provides-extras = ["lightgbm", "rdblearn", "rdl", "graphsage", "relgnn", "relgt"
 cpu = [{ name = "torch", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "relarena", group = "cpu" } }]
 cuda = []
 dev = [
-    { name = "fastdfs", specifier = ">=0.2.1" },
+    { name = "fastdfs", specifier = ">=1.1" },
     { name = "lightgbm", specifier = ">=4.0,<4.7" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=9.1.1" },


### PR DESCRIPTION
Generated by Claude Code

`fastdfs >= 1.1` renames every matrix column to `d{depth}__{name}`, while `_compute_depth_map` keyed on the bare `f.get_name()`. Every lookup misses, the `-1` sentinel defaults to *keep*, and each depth returns the full max-depth matrix.

`max_depth` is the tuned knob for `rdblearn`, `tabpfn-rel-local`, and `tabpfn-rel-client` (grid `{2,3,4}`, default `2`), so the whole grid collapses to one feature set and the default run silently gets depth-4 features.

Changes:
- require `fastdfs>=1.1` and key the depth map through `dfs_feature_column_name`, so the map and the matrix agree by construction
- raise when no matrix column is in the depth map, instead of silently keeping everything
- `_DFS_CACHE_VERSION` 2 -> 3, since existing matrices were written under the other naming

<details><summary>Evidence</summary>

`build_dfs_features` on rel-f1 `driver-position` at `max_depth=4`, column counts:

| | depth 2 | depth 3 | depth 4 |
| --- | --- | --- | --- |
| before | 686 | 686 | 686 |
| after | 87 | 120 | 686 |

The 87 matches a matrix cached under fastdfs 0.2.1, and depths 2 and 3 match a 0.2.1 run bit-for-bit.

Cached artifacts written under 1.1 show the mismatch directly — matrices prefixed, depth maps not:

```
matrix: 375/377 prefixed   depthmap: 413 entries, 0 prefixed   (rel-trial/study-adverse)
matrix:  91/93  prefixed   depthmap:  91 entries, 0 prefixed   (rel-hm/item-sales)
matrix: 1452/1454 prefixed depthmap: 2394 entries, 0 prefixed  (rel-event/user-repeat)
```

The existing tests covered the depth cache's memoization but nothing asserted that the map's keys match the matrix's columns, which is the contract that broke. The added test asserts it.

`tests/featurization/` passes (36 tests) against fastdfs 1.1.
</details>

<details><summary>Scope</summary>

Benchmark runs were not affected: `runner.py` resolves the cache with `on_miss="raise"`, so a miss fails loudly instead of computing a degenerate matrix, and the pre-warmed shared cache was built under 0.2.1. The exposed path is the warmer, which fills — running it under 1.1 writes a prefixed matrix beside a bare depth map and poisons the shared cache for every later run.

`_dfs_cache_key` carries no engine version, so matrices built by different fastdfs versions collide on one path. Worth fixing separately.
</details>