### PR TITLE
Prepare 0.0.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "relarena"
-version = "0.0.1a2"
+version = "0.0.2"
 authors = [{ name = "Prior Labs" }]
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "src/relarena/models/VENDORED-LICENSES"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "relarena"
-version = "0.0.2"
+version = "0.0.1"
 authors = [{ name = "Prior Labs" }]
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "src/relarena/models/VENDORED-LICENSES"]

--- a/src/relarena/__init__.py
+++ b/src/relarena/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "database_checksum",
     "split_checksums",
 ]
-__version__ = "0.0.1a2"
+__version__ = "0.0.2"

--- a/src/relarena/__init__.py
+++ b/src/relarena/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "database_checksum",
     "split_checksums",
 ]
-__version__ = "0.0.2"
+__version__ = "0.0.1"

--- a/uv.lock
+++ b/uv.lock
@@ -2085,7 +2085,7 @@ wheels = [
 
 [[package]]
 name = "relarena"
-version = "0.0.1a2"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "configspace" },

--- a/uv.lock
+++ b/uv.lock
@@ -2085,7 +2085,7 @@ wheels = [
 
 [[package]]
 name = "relarena"
-version = "0.0.2"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "configspace" },


### PR DESCRIPTION
Bumps RelArena to `0.0.1` in the three places that carry the version: `pyproject.toml`, `src/relarena/__init__.py`, and the `relarena` entry in `uv.lock`.

`0.0.1` is the first non-prerelease version. `0.0.1a1` is the only version currently on PyPI; `0.0.1a2` was bumped in `6de27e5` ("Enable RT extra from PyPI") but never published, so this release ships that change along with everything else since `0.0.1a1`. PEP 440 orders `0.0.1a1 < 0.0.1a2 < 0.0.1`, so `0.0.1` supersedes both.

**Note on who this reaches.** `0.0.1a1` is a pre-release that pip serves today only because it is the sole version on the index. Once `0.0.1` is published it becomes the default for every plain `pip install relarena`, including existing users on their next resolve.

The `uv.lock` change is a single hand-edited line — the version string on the `relarena` entry. Running `uv lock` under uv 0.11.16 also rewrites `exclude-newer` to a `0001-01-01` sentinel, which is unrelated format churn from a uv version difference (`exclude-newer-span = "P3D"` is what actually governs resolution). The minimal edit keeps this to the release change and matches the lockfile state CI already accepts. `uv lock --check` passes.

Verified locally: `uv build` produces `relarena-0.0.1-py3-none-any.whl` and `relarena-0.0.1.tar.gz`, and `workflows/verify_distributions.py` passes on both.

The branch is still named `release/0.0.2` from the first pass at this release; the version it ships is `0.0.1`.

After merge, publishing is still manual (no release workflow in the repo):

```
git checkout main && git pull
rm -rf dist && uv build
python workflows/verify_distributions.py
uv publish
git tag -a v0.0.1 -m "RelArena 0.0.1" && git push origin v0.0.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuHUrzqnospR8jMngDGpdo
