### PR TITLE
Import the DFS column namer lazily, not at module scope

### DIFF
--- a/src/relarena/featurization/dfs.py
+++ b/src/relarena/featurization/dfs.py
@@ -47,10 +47,6 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Callable
 
 import pandas as pd
-
-# The engine names matrix columns `d{depth}__{feature}`; the depth map must use the
-# same names or every lookup misses.
-from fastdfs.dfs import dfs_feature_column_name
 from relbench.base import Database, EntityTask, Table
 
 from relarena.cache import CacheConfig, cache_key
@@ -538,8 +534,13 @@ def build_dfs_features(
     `build_entity_features`; the caller freezes a consistent categorical encoding
     across splits.
     """
+    # Local, like every other `fastdfs` import in this module: the DFS deps are an
+    # extra, so a module-scope import makes `relarena.featurization` unimportable
+    # without it — which silently drops every model that imports this package from
+    # the registry, since the discovery scan treats a missing third-party module as
+    # an absent optional extra.
     from fastdfs import DFSConfig, compute_dfs_features
-    from fastdfs.dfs import get_dfs_engine
+    from fastdfs.dfs import dfs_feature_column_name, get_dfs_engine
     from fastdfs.utils.type_utils import safe_convert_to_string
 
     cache = cache or CacheConfig(directory=None, on_miss="compute")
@@ -606,6 +607,8 @@ def build_dfs_features(
             # `compute_dfs_features`) rejects it. Run it on a shallow-frame copy,
             # never the cached RDB: the mutation only *adds* a column, so a
             # `copy(deep=False)` (shared column data, no duplication) suffices.
+            # The engine names matrix columns `d{depth}__{feature}`; the depth map
+            # must use the same names or every lookup misses.
             return {
                 dfs_feature_column_name(f): f.get_depth()
                 for f in get_dfs_engine(cfg.engine, cfg).prepare_features(

--- a/src/relarena/featurization/dfs.py
+++ b/src/relarena/featurization/dfs.py
@@ -534,11 +534,9 @@ def build_dfs_features(
     `build_entity_features`; the caller freezes a consistent categorical encoding
     across splits.
     """
-    # Local, like every other `fastdfs` import in this module: the DFS deps are an
-    # extra, so a module-scope import makes `relarena.featurization` unimportable
-    # without it — which silently drops every model that imports this package from
-    # the registry, since the discovery scan treats a missing third-party module as
-    # an absent optional extra.
+    # The DFS deps are an extra, so these imports stay function-local: at module
+    # scope they make `relarena.featurization` unimportable without the extra,
+    # which silently drops every model that imports it from the registry.
     from fastdfs import DFSConfig, compute_dfs_features
     from fastdfs.dfs import dfs_feature_column_name, get_dfs_engine
     from fastdfs.utils.type_utils import safe_convert_to_string
@@ -607,6 +605,7 @@ def build_dfs_features(
             # `compute_dfs_features`) rejects it. Run it on a shallow-frame copy,
             # never the cached RDB: the mutation only *adds* a column, so a
             # `copy(deep=False)` (shared column data, no duplication) suffices.
+
             # The engine names matrix columns `d{depth}__{feature}`; the depth map
             # must use the same names or every lookup misses.
             return {

--- a/tests/models/test_discovery.py
+++ b/tests/models/test_discovery.py
@@ -67,13 +67,10 @@ def _registered_names(*args: str) -> list[str]:
 def test__register_builtin_models__without_the_dfs_extra__same_models() -> None:
     """Registration is dep-free: an absent extra must not drop a model.
 
-    The dev group installs `fastdfs`, so a `fastdfs` import that escapes to module
-    scope in `relarena.featurization` is invisible to the rest of the suite. It
-    surfaces only on an install without the DFS extra, where the scan reads the
-    ImportError as an absent optional dep and every model importing that package
-    -- `lightgbm` included, which only wants entity features -- goes quietly
-    missing. Compare the whole registry rather than named models so any such
-    import is caught, wherever it lands.
+    The dev group installs `fastdfs`, so a module-scope import of it is invisible
+    to the rest of the suite — it surfaces only on an install without the DFS
+    extra, where the scan reads the ImportError as an absent optional dep and the
+    model goes quietly missing.
     """
     assert _registered_names("--without-dfs-extra") == _registered_names()
 

--- a/tests/models/test_discovery.py
+++ b/tests/models/test_discovery.py
@@ -8,6 +8,7 @@ the real module, so nothing else importing during the test is affected.
 
 from __future__ import annotations
 
+import json
 import logging
 import pkgutil
 import subprocess
@@ -27,6 +28,54 @@ def test__import_models__does_not_import_preprocessing_warmers() -> None:
         "assert 'relarena.models.relgt.warm_cache' not in sys.modules"
     )
     subprocess.run([sys.executable, "-c", code], check=True)
+
+
+_REGISTRY_NAMES = """
+import json
+import sys
+
+if "--without-dfs-extra" in sys.argv:
+
+    class _Hidden:
+        '''Make `fastdfs` unimportable, as on an install without the DFS extra.'''
+
+        def find_spec(self, name, path=None, target=None):
+            if name == "fastdfs" or name.startswith("fastdfs."):
+                raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+            return None
+
+    sys.meta_path.insert(0, _Hidden())
+
+import relarena.models  # noqa: F401  - importing runs the registration scan
+from relarena import registry
+
+print(json.dumps(sorted(registry.names())))
+"""
+
+
+def _registered_names(*args: str) -> list[str]:
+    """Names in the registry of a fresh interpreter, run with `args`."""
+    result = subprocess.run(
+        [sys.executable, "-c", _REGISTRY_NAMES, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout.splitlines()[-1])
+
+
+def test__register_builtin_models__without_the_dfs_extra__same_models() -> None:
+    """Registration is dep-free: an absent extra must not drop a model.
+
+    The dev group installs `fastdfs`, so a `fastdfs` import that escapes to module
+    scope in `relarena.featurization` is invisible to the rest of the suite. It
+    surfaces only on an install without the DFS extra, where the scan reads the
+    ImportError as an absent optional dep and every model importing that package
+    -- `lightgbm` included, which only wants entity features -- goes quietly
+    missing. Compare the whole registry rather than named models so any such
+    import is caught, wherever it lands.
+    """
+    assert _registered_names("--without-dfs-extra") == _registered_names()
 
 
 def _record_imports(monkeypatch: pytest.MonkeyPatch, fail: dict[str, str]) -> list[str]:


### PR DESCRIPTION
## The bug

`pip install "relarena[lightgbm]"` on 0.0.1 gives you a registry with **7** models. It should have 11 — `lightgbm`, `rdblearn`, `tabpfn-rel-client` and `tabpfn-rel-local` are silently missing:

```
LOG Skipping model 'lightgbm': optional dependency 'fastdfs' is not installed.
RESULT registered: ['constant-global', 'constant-per-entity', 'graphsage',
                    'relgnn', 'relgnn-es', 'relgt', 'rt-plurel']
```

`ba4e6c9` (in #13) moved `from fastdfs.dfs import dfs_feature_column_name` to module scope in `featurization/dfs.py`. Bumping the `fastdfs` floor in the *extras* doesn't put it in a core install, so the import became unconditional while the dependency stayed optional. `featurization/__init__.py` imports `dfs` eagerly, so any importer of the package now hard-requires `fastdfs` — including `models/lightgbm/model.py`, which only wants `build_entity_features`.

It fails *silently* because `models/__init__.py` deliberately skips a wrapper whose third-party dep is missing. Right for `rdblearn`; wrong here, and it downgrades a defect to an INFO log. It also breaks the layering rule in `AGENTS.md` ("heavy optional deps are lazy-imported inside `fit` behind extras").

Confirmed a regression, not pre-existing — same clean-venv test against each published version:

| | registered models |
|---|---|
| 0.0.1a1 (before #13) | 11 |
| 0.0.1 (shipped) | 7 |

## The fix

One import moved into the function-local `fastdfs` block `build_dfs_features` already has, with a comment on why it belongs there. Building this branch and installing the wheel with `[lightgbm]` and no `fastdfs` gives 11 models again.

## Why CI was green

The `dev` group installs `fastdfs>=1.1`, so a module-scope import of it is invisible to the suite. Added a discovery test that hides `fastdfs` behind a `meta_path` finder in a subprocess and compares the *whole* registry against a normal run — so any future escape to module scope is caught wherever it lands, not just for the models we happen to name. Verified it fails on the current `main` and passes here.

Full suite: 401 passed, 10 skipped.

## Follow-ups (not in this PR)

- A release gate that installs the built artifact into a clean env without the `dev` group — the check that would have caught this before upload rather than after.
- `README.md:281` ("No `--pre` flag is needed while the α-release is the only published version") is stale now that 0.0.1 exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)