### PR TITLE
AGENTS.md: state the public-surface constraint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 Start with the [README](README.md) for what the package is and how a run works.
 
+## This repo is public
+
+Everything committed here is published under Apache-2.0 — code, docs, and
+`baseline_results/` alike. Nothing may reference Prior Labs–internal
+infrastructure, systems, names, or paths. This applies to everything pushed
+to the remote, not just tracked files: commit messages, branch names, and PR
+text included.
+
 ## Adding or changing a model
 
 Read [docs/adding-a-model.md](docs/adding-a-model.md) first. Model development


### PR DESCRIPTION
Adds a short section to AGENTS.md stating that everything committed to this repo — code, docs, and `baseline_results/` — is published under Apache-2.0 and must not reference Prior Labs–internal infrastructure, systems, names, or paths.

Kept deliberately generic: the note itself is public, so it states the boundary without an inventory of what sits behind it. The concrete export rules live with the internal tooling that produces the committed results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)