### PR TITLE
Filter leaderboards by task subset; drop incomplete methods, not tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ entity-level RelBench v1 tasks:
 
 | File | Contents |
 |---|---|
-| `results.csv` | Every evaluated config of the release sweep (7 databases, 21 tasks, seed 0). Feed it to `compute_leaderboard`; filter on `selected` for the tuned board. |
+| `results.csv` | Every evaluated config of the release sweep (7 databases, 21 tasks, seed 0). Feed it to `compute_leaderboard`; pass `subset=` to filter which tasks the board covers. |
 | `experiment_results.csv` | Same schema, for exploratory runs deliberately **excluded** from the default leaderboard (currently the experimental full-data-refit `relgnn` variant). |
 | `reference_results.csv` | Per-task scores for methods **not reproduced in this pipeline**, transcribed from published model reports and flagged with a `_MR` (**model report**) suffix. |
 
@@ -260,6 +260,29 @@ average ranks, bootstrapped Elo ratings with confidence intervals, pairwise win 
 normalized or baseline-relative scores (needs the `leaderboard` extra). Normalized-loss heatmaps
 and the critical-difference diagram come from `relarena.evaluation.write_leaderboard_plots` with
 the `plots` extra.
+
+A board covers the tasks present in the frame you hand it, and any method without a result on
+every one of them is dropped, with a warning naming it. `subset=` allows for creating custom
+leaderboards computed on a restricted set of tasks. The filtering is run before the completeness
+check mentioned above. `SUBSETS` ships two examples, allowing easy comparison on only
+classification or regression tasks:
+
+```python
+from relarena.evaluation import compute_leaderboard
+
+overall = compute_leaderboard(results)  # every task in the frame
+classification = compute_leaderboard(results, subset="classification")
+regression = compute_leaderboard(results, subset="regression")
+```
+
+In addition to providing a registry of example subsets, it is also easy to define custom
+filters using `lambda` functions:
+
+```python
+board = compute_leaderboard(results, subset=lambda d: d["dataset"] == "rel-f1")
+```
+
+The `subset` argument of `write_leaderboard_plots` works analogously.
 
 </details>
 

--- a/src/relarena/evaluation/__init__.py
+++ b/src/relarena/evaluation/__init__.py
@@ -2,7 +2,8 @@
 
 Everything here consumes a finished results frame and never takes part in a run,
 so nothing in the harness core (`model`, `tuner`, `runner`, `metrics`) may import
-it. `reference` supplies externally-reported scores to rank alongside our own.
+it. `reference` supplies externally-reported scores to rank alongside our own,
+and `subsets` names the task slices a custom leaderboard can be built on.
 """
 
 from relarena.evaluation.leaderboard import (
@@ -11,15 +12,21 @@ from relarena.evaluation.leaderboard import (
     to_bencheval_frame,
 )
 from relarena.evaluation.plots import (
+    plot_critical_difference,
     plot_normalized_loss_heatmap,
     write_leaderboard_plots,
 )
 from relarena.evaluation.reference import load_reference_results
+from relarena.evaluation.subsets import SUBSETS, TaskMask, apply_subset
 
 __all__ = [
+    "SUBSETS",
+    "TaskMask",
+    "apply_subset",
     "compute_leaderboard",
     "load_reference_results",
     "method_kind",
+    "plot_critical_difference",
     "plot_normalized_loss_heatmap",
     "to_bencheval_frame",
     "write_leaderboard_plots",

--- a/src/relarena/evaluation/leaderboard.py
+++ b/src/relarena/evaluation/leaderboard.py
@@ -9,6 +9,9 @@ Two steps:
 - `compute_leaderboard` ranks that frame with `bencheval.BenchmarkEvaluator`.
   `bencheval` is the optional `leaderboard` extra, imported lazily inside the
   function so importing this module stays dependency-free.
+
+The board's task set comes from the frame it is given (optionally narrowed by a
+`subsets.TaskSubset`); methods that do not cover it are dropped.
 """
 
 from __future__ import annotations
@@ -17,6 +20,7 @@ import logging
 
 import pandas as pd
 
+from relarena.evaluation.subsets import TaskMask, apply_subset
 from relarena.metrics import to_metric_error
 
 logger = logging.getLogger(__name__)
@@ -68,27 +72,28 @@ def to_bencheval_frame(results: pd.DataFrame) -> pd.DataFrame:
     return frame[frame["metric_error"].notna()].reset_index(drop=True)
 
 
-def _drop_incomplete_tasks(frame: pd.DataFrame) -> pd.DataFrame:
-    """Drop tasks not run by every method, logging them.
+def _drop_incomplete_methods(frame: pd.DataFrame) -> pd.DataFrame:
+    """Drop methods without a result on every task in the frame, logging them.
 
-    `bencheval` requires a dense method × task matrix; a partial sweep would
-    otherwise hard-fail. Logging the dropped tasks keeps the shrink visible
-    instead of silent.
+    `bencheval` requires a dense method × task matrix, and one row per
+    (method, task) as `to_bencheval_frame` produces. Dropping the *methods*
+    rather than the tasks keeps the task set fixed by the frame, so one
+    method's partial coverage never shrinks the board the others are ranked on;
+    narrow the frame with `subset=` to rank it on a set it does cover.
     """
     if frame.empty:
         return frame
-    n_methods = frame["method"].nunique()
-    per_task = frame.groupby("task")["method"].nunique()
-    complete = per_task[per_task == n_methods].index
-    dropped = sorted(set(per_task.index) - set(complete))
-    if dropped:
+    n_tasks = frame["task"].nunique()
+    per_method = frame.groupby("method")["task"].nunique()
+    dropped = per_method[per_method < n_tasks]
+    if not dropped.empty:
         logger.warning(
-            "Leaderboard: dropping %d task(s) not run by all %d methods: %s",
+            "Leaderboard: dropping %d method(s) without a result on all %d tasks: %s",
             len(dropped),
-            n_methods,
-            ", ".join(dropped),
+            n_tasks,
+            ", ".join(f"{m} (missing {n_tasks - n})" for m, n in dropped.items()),
         )
-    return frame[frame["task"].isin(complete)].reset_index(drop=True)
+    return frame[~frame["method"].isin(dropped.index)].reset_index(drop=True)
 
 
 def method_kind(model: str) -> str:
@@ -119,18 +124,23 @@ def compute_leaderboard(
     reference: pd.DataFrame | None = None,
     baseline_method: str | None = "constant-global",
     kinds: frozenset[str] | None = None,
+    subset: str | TaskMask = "all",
 ) -> pd.DataFrame:
     """Rank a RelArena results frame into a TabArena-style leaderboard.
 
-    Builds the bencheval input with `to_bencheval_frame`, drops tasks not
-    run by every method (see `_drop_incomplete_tasks`), then ranks with
+    Builds the bencheval input with `to_bencheval_frame`, drops methods that
+    did not run every task (see `_drop_incomplete_methods`), then ranks with
     `bencheval.BenchmarkEvaluator`. The board is sorted by normalized loss
     (`loss_rescaled` — per-task min-max error averaged across tasks) and also
     reports mean rank, win-rate, and ELO. ELO is anchored on `baseline_method`
     so its scale is stable across runs; the anchor is ignored if that method is
     absent, and ELO is skipped entirely for a single method (it scores pairwise
-    comparisons, of which there are none). Returns an empty frame if no complete
-    task remains.
+    comparisons, of which there are none). Returns an empty frame if no method
+    covers the whole task set.
+
+    `subset` narrows the board's tasks (see `relarena.evaluation.subsets`),
+    applied before the density check so a method covering only that subset ranks
+    here while the full board still drops it.
 
     Pass `reference` (a frame from `relarena.evaluation.load_reference_results`)
     to rank self-reported baselines alongside the reproduced runs as ordinary
@@ -148,7 +158,8 @@ def compute_leaderboard(
         results = pd.concat([results, reference], ignore_index=True)
     if kinds is not None:
         results = results[results["model"].map(method_kind).isin(kinds)]
-    frame = _drop_incomplete_tasks(to_bencheval_frame(results))
+    results = apply_subset(results, subset)
+    frame = _drop_incomplete_methods(to_bencheval_frame(results))
     if frame.empty:
         return pd.DataFrame()
     anchor = baseline_method if baseline_method in set(frame["method"]) else None

--- a/src/relarena/evaluation/plots.py
+++ b/src/relarena/evaluation/plots.py
@@ -23,9 +23,10 @@ from pathlib import Path
 import pandas as pd
 
 from relarena.evaluation.leaderboard import (
-    _drop_incomplete_tasks,
+    _drop_incomplete_methods,
     to_bencheval_frame,
 )
+from relarena.evaluation.subsets import TaskMask, apply_subset
 
 _TASK_TYPE_LABELS = {
     "BINARY_CLASSIFICATION": "classification",
@@ -35,6 +36,12 @@ _TASK_TYPE_LABELS = {
 
 #: Dark end of the white->blue heatmap ramps.
 _HEATMAP_BLUE = "#08519c"
+
+#: `autorank`, behind the critical-difference diagram, refuses fewer tasks (its
+#: "performance estimations") or methods than these. A narrow `subset` can fall
+#: below either, so the diagram is skipped rather than raising.
+_CD_MIN_TASKS = 5
+_CD_MIN_METHODS = 2
 
 
 def _normalized_loss(results: pd.DataFrame) -> pd.DataFrame:
@@ -217,13 +224,18 @@ def plot_raw_score_heatmap(
 def plot_critical_difference(results: pd.DataFrame, save_path: str | Path) -> bool:
     """Write bencheval's critical-difference diagram over mean ranks.
 
-    Returns `False` (writing nothing) when no dense task remains to rank.
+    Returns `False` (writing nothing) when nothing remains to rank, or when
+    fewer than five tasks or two methods do, which `autorank` refuses to run on.
     """
     import matplotlib.pyplot as plt
     from bencheval.evaluator import BenchmarkEvaluator
 
-    frame = _drop_incomplete_tasks(to_bencheval_frame(results))
-    if frame.empty:
+    frame = _drop_incomplete_methods(to_bencheval_frame(results))
+    if (
+        frame.empty
+        or frame["task"].nunique() < _CD_MIN_TASKS
+        or frame["method"].nunique() < _CD_MIN_METHODS
+    ):
         return False
 
     board = BenchmarkEvaluator()
@@ -240,12 +252,12 @@ def plot_critical_difference(results: pd.DataFrame, save_path: str | Path) -> bo
 def plot_winrate_matrix(results: pd.DataFrame, save_path: str | Path) -> bool:
     """Write bencheval's pairwise win-rate matrix (% of tasks method i beats j).
 
-    Returns `False` (writing nothing) when no dense task remains to rank.
+    Returns `False` (writing nothing) when no method covers the whole task set.
     """
     import matplotlib.pyplot as plt
     from bencheval.evaluator import BenchmarkEvaluator
 
-    frame = _drop_incomplete_tasks(to_bencheval_frame(results))
+    frame = _drop_incomplete_methods(to_bencheval_frame(results))
     if frame.empty:
         return False
 
@@ -265,6 +277,7 @@ def write_leaderboard_plots(
     out_dir: str | Path,
     *,
     reference: pd.DataFrame | None = None,
+    subset: str | TaskMask = "all",
 ) -> list[Path]:
     """Write all leaderboard plots into `out_dir`; return the paths written.
 
@@ -274,10 +287,15 @@ def write_leaderboard_plots(
 
     Pass `reference` (a frame from `relarena.evaluation.load_reference_results`)
     to show self-reported baselines alongside the reproduced runs as ordinary
-    methods.
+    methods, and `subset` (see `relarena.evaluation.subsets`) to narrow every
+    plot to one task subset.
+
+    The heatmaps keep sparse cells, while the win-rate matrix and
+    critical-difference diagram drop incomplete methods as the leaderboard does.
     """
     if reference is not None:
         results = pd.concat([results, reference], ignore_index=True)
+    results = apply_subset(results, subset)
     out_dir = Path(out_dir)
     written: list[Path] = []
     for task_type, label in _TASK_TYPE_LABELS.items():

--- a/src/relarena/evaluation/subsets.py
+++ b/src/relarena/evaluation/subsets.py
@@ -1,0 +1,40 @@
+"""Task subsets for filtering a leaderboard.
+
+A subset is a mask over a RelArena results frame. `compute_leaderboard` and
+`write_leaderboard_plots` take one as `subset=`, applied *before* their density
+check: the filtered frame's task set is the one methods must cover, so a method
+present on only part of the full frame can still rank on a subset it does cover.
+
+`SUBSETS` maps names to masks — `"all"`, the default no-op, plus two examples.
+Anything else is a mask of your own. Which slices make a comparable board is
+the caller's call, not this module's.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pandas as pd
+
+#: A subset mask: a results frame in, a boolean `Series` out.
+TaskMask = Callable[[pd.DataFrame], pd.Series]
+
+#: Example subsets, keyed on the results schema's own columns. `task_type` holds
+#: `TaskType` *names* (`summary_to_dataframe` writes `task_type.name`), the same
+#: spelling `plots._TASK_TYPE_LABELS` uses.
+SUBSETS: dict[str, TaskMask] = {
+    "all": lambda d: pd.Series(True, index=d.index),
+    "classification": lambda d: d["task_type"] == "BINARY_CLASSIFICATION",
+    "regression": lambda d: d["task_type"] == "REGRESSION",
+}
+
+
+def apply_subset(results: pd.DataFrame, subset: str | TaskMask) -> pd.DataFrame:
+    """Filter a results frame to `subset`: a `SUBSETS` name or a mask of your own."""
+    if isinstance(subset, str):
+        if subset not in SUBSETS:
+            raise ValueError(
+                f"Unknown task subset {subset!r}; known: {sorted(SUBSETS)}."
+            )
+        subset = SUBSETS[subset]
+    return results[subset(results)]

--- a/tests/evaluation/test_leaderboard.py
+++ b/tests/evaluation/test_leaderboard.py
@@ -17,6 +17,12 @@ _BASELINE_DIR = Path(__file__).resolve().parents[2] / "baseline_results"
 _REFERENCE_CSV = _BASELINE_DIR / "reference_results.csv"
 
 
+#: The task type each primary metric belongs to (`roc_auc` is the binary
+#: primary, `mae` the regression one), so `_result` rows carry a `task_type`
+#: the subset filters can read.
+_TASK_TYPE_OF = {"roc_auc": "BINARY_CLASSIFICATION", "mae": "REGRESSION"}
+
+
 def _result(
     model: str,
     dataset: str,
@@ -30,6 +36,7 @@ def _result(
         "model": model,
         "dataset": dataset,
         "task": task,
+        "task_type": _TASK_TYPE_OF[metric],
         "metric": metric,
         "selected": selected,
         "test_score": test_score,
@@ -143,9 +150,10 @@ def test__compute_leaderboard__single_method__ranks_without_elo() -> None:
     assert board.loc["lightgbm", "rank"] == pytest.approx(1.0)
 
 
-def test__compute_leaderboard__incomplete_task__is_dropped() -> None:
+def test__compute_leaderboard__incomplete_method__is_dropped() -> None:
     pytest.importorskip("bencheval.evaluator")
-    # rel-hm/user-churn is missing lightgbm -> dropped, leaving one dense task.
+    # lightgbm is missing rel-hm/user-churn -> lightgbm goes, both tasks stay,
+    # so one method's partial sweep never shrinks the board for the others.
     results = pd.DataFrame(
         [
             _result("constant-global", "rel-f1", "driver-dnf", "roc_auc", 0.5),
@@ -155,10 +163,56 @@ def test__compute_leaderboard__incomplete_task__is_dropped() -> None:
     )
 
     board = compute_leaderboard(results)
-    assert set(board.index) == {
+    assert set(board.index) == {"constant-global"}
+
+
+def _mixed_results() -> pd.DataFrame:
+    """Two task types x two methods, plus one method that only does regression."""
+    rows = []
+    for model, score in (("constant-global", 0.5), ("lightgbm", 0.9)):
+        rows.append(_result(model, "rel-f1", "driver-dnf", "roc_auc", score))
+        rows.append(_result(model, "rel-hm", "user-churn", "mae", 1.0 - score))
+    rows.append(_result("regression-only", "rel-hm", "user-churn", "mae", 0.05))
+    return pd.DataFrame(rows)
+
+
+def test__compute_leaderboard__subset__ranks_only_that_task_type() -> None:
+    pytest.importorskip("bencheval.evaluator")
+    results = _mixed_results()
+
+    classification = compute_leaderboard(results, subset="classification")
+
+    # the regression-only method never entered, and neither did its task
+    assert set(classification.index) == {"constant-global", "lightgbm"}
+    assert classification.loc["lightgbm", "rank"] == pytest.approx(1.0)
+
+
+def test__compute_leaderboard__narrow_method__ranks_only_on_its_subset() -> None:
+    pytest.importorskip("bencheval.evaluator")
+    # A method covering one task type only: absent from the full board (it
+    # cannot cover it), ranked on the subset it does cover, and the full board
+    # is the same with or without it.
+    results = _mixed_results()
+    without = results[results["model"] != "regression-only"]
+
+    full = compute_leaderboard(results)
+    regression = compute_leaderboard(results, subset="regression")
+
+    assert "regression-only" not in set(full.index)
+    assert set(full.index) == set(compute_leaderboard(without).index)
+    assert set(regression.index) == {
         "constant-global",
         "lightgbm",
-    }  # both methods still ranked
+        "regression-only",
+    }
+    # it wins that board: mae 0.05 beats both
+    assert regression.loc["regression-only", "rank"] == pytest.approx(1.0)
+
+
+def test__compute_leaderboard__unknown_subset__raises() -> None:
+    pytest.importorskip("bencheval.evaluator")
+    with pytest.raises(ValueError, match="Unknown task subset 'tiny'"):
+        compute_leaderboard(_mixed_results(), subset="tiny")
 
 
 def test__compute_leaderboard__checked_in_baselines__produce_a_board() -> None:

--- a/tests/evaluation/test_plots.py
+++ b/tests/evaluation/test_plots.py
@@ -15,6 +15,7 @@ pytest.importorskip("seaborn")
 pytest.importorskip("bencheval.evaluator")  # heatmaps use bencheval loss_rescaled
 
 from relarena.evaluation import (
+    plot_critical_difference,
     plot_normalized_loss_heatmap,
     write_leaderboard_plots,
 )
@@ -37,23 +38,22 @@ def _result(
     }
 
 
-def _dense_results() -> pd.DataFrame:
+def _dense_results(n_tasks_per_type: int = 3) -> pd.DataFrame:
     rows = []
     for i, model in enumerate(["constant-global", "lightgbm", "rdblearn"]):
-        for task in ("a", "b", "c"):
+        for t in range(n_tasks_per_type):
             rows.append(
                 _result(
                     model,
                     "rel-d",
-                    task,
+                    f"cls-{t}",
                     "BINARY_CLASSIFICATION",
                     "roc_auc",
                     0.5 + 0.1 * i,
                 )
             )
-        for task in ("x", "y", "z"):
             rows.append(
-                _result(model, "rel-d", task, "REGRESSION", "mae", 1.0 - 0.2 * i)
+                _result(model, "rel-d", f"reg-{t}", "REGRESSION", "mae", 1.0 - 0.2 * i)
             )
     df = pd.DataFrame(rows)
     # native-metric columns the raw heatmaps read (NaN where the metric doesn't apply)
@@ -94,3 +94,34 @@ def test__write_leaderboard_plots__dense_results__writes_heatmaps_and_cd(
     }
     for path in written:
         assert path.exists() and path.stat().st_size > 0
+
+
+def test__write_leaderboard_plots__subset__skips_the_excluded_task_type(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("bencheval.evaluator")
+    pytest.importorskip("autorank")
+
+    # five tasks per type, so the subset still clears autorank's minimum
+    written = write_leaderboard_plots(_dense_results(5), tmp_path, subset="regression")
+
+    # no classification task survives the subset, so neither its normalized-loss
+    # heatmap nor the ROC AUC one has anything to draw
+    assert {p.name for p in written} == {
+        "heatmap_regression.png",
+        "heatmap_r2.png",
+        "winrate_matrix.png",
+        "critical_difference.png",
+    }
+
+
+def test__plot_critical_difference__too_few_tasks__writes_nothing(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("autorank")
+    out = tmp_path / "cd.png"
+
+    # three tasks is below autorank's five-task minimum: skip, do not raise
+    three_tasks = _dense_results(3).query("task_type == 'REGRESSION'")
+    assert plot_critical_difference(three_tasks, out) is False
+    assert not out.exists()

--- a/tests/evaluation/test_subsets.py
+++ b/tests/evaluation/test_subsets.py
@@ -1,0 +1,56 @@
+"""Tests for the task subsets behind custom leaderboards."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from relarena.evaluation import apply_subset
+
+_RESULTS = pd.DataFrame(
+    [
+        {"model": "lightgbm", "dataset": "rel-f1", "task_type": "REGRESSION"},
+        {
+            "model": "lightgbm",
+            "dataset": "rel-hm",
+            "task_type": "BINARY_CLASSIFICATION",
+        },
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("all", {"REGRESSION", "BINARY_CLASSIFICATION"}),
+        ("regression", {"REGRESSION"}),
+        ("classification", {"BINARY_CLASSIFICATION"}),
+    ],
+)
+def test__apply_subset__name__keeps_that_task_type(
+    name: str, expected: set[str]
+) -> None:
+    assert set(apply_subset(_RESULTS, name)["task_type"]) == expected
+
+
+def test__apply_subset__task_type_names__partition_the_frame() -> None:
+    # Guard: the two task-type subsets must not overlap or leave a task behind,
+    # or a board built per task type would double-count or silently skip one.
+    classification = apply_subset(_RESULTS, "classification")
+    regression = apply_subset(_RESULTS, "regression")
+    assert len(classification) + len(regression) == len(_RESULTS)
+
+
+def test__apply_subset__own_mask__filters_by_it() -> None:
+    only_f1 = apply_subset(_RESULTS, lambda d: d["dataset"] == "rel-f1")
+    assert set(only_f1["dataset"]) == {"rel-f1"}
+
+
+def test__apply_subset__unknown_name__raises_listing_the_known_ones() -> None:
+    with pytest.raises(ValueError, match="Unknown task subset 'tiny'"):
+        apply_subset(_RESULTS, "tiny")
+
+
+def test__apply_subset__all__works_without_task_metadata() -> None:
+    # The default must not require any column beyond what it is handed.
+    assert len(apply_subset(pd.DataFrame({"model": ["lightgbm"]}), "all")) == 1


### PR DESCRIPTION
## What

Two changes to `relarena.evaluation`:

1. The leaderboard's density repair drops **methods** that lack a result on some task,
   rather than dropping **tasks** that some method lacks. `bencheval` needs a dense
   method × task matrix; which side gives way decides whether one submission can reshape
   the board everyone else is ranked on.
2. A `subset=` keyword on `compute_leaderboard` and `write_leaderboard_plots` filters
   which tasks a board covers. `SUBSETS` ships two examples, `"classification"` and
   `"regression"`; any other slice is a mask of your own.

## Why

Raised in #16: a method that supports only one task type could not be reported. Adding its
results to the frame removed every task it had not run from the board — over the 21 released
tasks, one regression-only entry took the board from 21 tasks to 9 for all eleven methods.

Both views the issue asks for now fall out of one mechanism:

| call | ranked |
| --- | --- |
| `compute_leaderboard(results)` | 10 methods × 21 tasks; the regression-only entry dropped, with a warning naming it and the count it is missing |
| `compute_leaderboard(results, subset="regression")` | 11 methods × 9 tasks, the regression-only entry among them |
| `compute_leaderboard(results, subset="classification")` | 10 methods × 12 tasks |

This follows the convention in TabArena's own evaluation, where the task set is fixed by the
benchmark and incomplete methods are imputed or removed, never the tasks.

The two named subsets are examples of the mechanism, not a set of endorsed leaderboards: which
slices make a comparable board, and which are worth publishing, is left to whoever builds one.

## Released numbers

Unchanged. `baseline_results/results.csv` is a complete 10 × 21 matrix, so both the old and the
new density rule are no-ops on it.

## Notes

- Dataset-size subsets (small/medium/large) need a per-task metadata table this repo does not
  have yet, joined onto the results frame before the mask runs. The mechanism is ready for them;
  the metadata is the missing piece.
- Subsetting made a latent crash reachable: `autorank` refuses fewer than five tasks or two
  methods, so `plot_critical_difference` raised on a narrow board instead of skipping. It now
  returns `False` like every other plot with nothing to draw.
- The heatmaps keep sparse cells; only the ranked outputs (leaderboard, win-rate matrix,
  critical-difference diagram) require full coverage.
- The `results.csv` row in the README no longer suggests filtering on `selected`:
  `compute_leaderboard` applies that filter itself, and filtering the other way for an untuned
  board yields a sparse matrix rather than the untuned board. Left for separate work.
- `plot_critical_difference` is now re-exported from `relarena.evaluation`, so its test can
  import it through the public API.

## Testing

- `OMP_NUM_THREADS=1 uv run pytest` — 413 passed, 10 skipped, with the `leaderboard` and
  `plots` extras installed.
- `uv run ruff format --check .` and `uv run ruff check .` — clean.
