### PR TITLE
Add first-class systems API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tabular benchmarks such as [TabArena](https://tabarena.ai). This repository also
 **TabPFN-Rel**, our relational harness for TabPFN-3, and an initial version of the
 **Relational Predictive Interface (RPI)**. What the framework contributes:
 
-- **Reproducibility.** Every reported method re-run through one unified model API, with
+- **Reproducibility.** Every reported method re-run through explicit model and system APIs, with
   implementations aligned, bugs fixed, and missing training scripts reconstructed.
 - **Tuning regimes.** Model submissions declare only a search space and are tuned by the
   framework; system submissions bring their own regime.
@@ -114,7 +114,8 @@ preprocessing cost.
 We want the set of included baselines to be as representative as possible, so adding a method is
 meant to be cheap. A model is a folder under `src/relarena/models/` implementing the
 `RelArenaModel` contract (`fit` and `predict`) with a `SearchSpace` registered via
-`@register_model(search_space=...)`; the registry discovers the folder automatically.
+`@register_model(search_space=...)`; an end-to-end procedure implements
+`RelArenaSystem.run` and uses `@register_system`. The registry discovers the folder automatically.
 `models/lightgbm/` is the smallest complete example to copy.
 
 The full guide is [docs/adding-a-model.md](docs/adding-a-model.md): the layout, the datatypes
@@ -420,11 +421,12 @@ boundaries are not yet standardized across methods.
 
 **Runtime policy.** The current policy allows a maximum total runtime of 24 hours per task,
 including preprocessing, measured on the largest tasks; moderately larger search spaces are
-permitted on smaller tasks when their cost stays reasonable. All released baseline models except
-RelGT run for less than 12 hours per task. Because equalizing tuning compute across methods
-remains unsolved, the α-release uses documented, method-specific trial budgets chosen to
-approximately balance compute. See [docs/tuning-regime.md](docs/tuning-regime.md), and the
-forthcoming model report for the full budget rationale.
+permitted on smaller tasks when their cost stays reasonable. The 24-hour limit is a ceiling, not a
+target; all released baseline models except RelGT run for less than 12 hours even on the largest
+tasks. Because equalizing tuning compute across methods remains unsolved, the α-release uses
+documented, method-specific trial budgets chosen to approximately balance compute. See
+[docs/tuning-regime.md](docs/tuning-regime.md), and the forthcoming model report for the full
+budget rationale.
 
 **What a run records.** Each trial keeps its configuration, metrics, optional predictions, and
 separate tuning and final-fit timings, which is what makes tunability analyses and per-phase

--- a/docs/adding-a-model.md
+++ b/docs/adding-a-model.md
@@ -125,44 +125,88 @@ split construction in [`dataset.py`](../src/relarena/dataset.py).
 | `name` | unique string | — | required |
 | `supported_task_types` | `ENTITY_TASK_TYPES`, or a narrower frozenset | all entity task types | `graphsage`, `relgt` → binary + regression only. Runner refuses out-of-set tasks rather than producing a meaningless number |
 | `refit_on_full_data` | `True` / `False` | `True` | `relgt`, `relgnn-es`, `rdblearn` → `False` |
-| `kind` | `"model"` / `"system"` | `"model"` | `rt-plurel` → `"system"` |
-
 `refit_on_full_data` is a genuine modelling decision, not just a flag — see
 [3e](#3e-refit-on-full-data).
 
 ### Model or system?
 
-Declare `kind = "system"` when the entry does its selection *inside* `fit`
-instead of through the registered search space — its own hyperparameter
-search, training-budget selection, component choices, or a pretrained recipe
-the harness cannot decompose. Systems and models are not the same kind of
-result: both face the same tasks, splits, metrics, and budget, so the
-comparison is fair on final performance, but a model's score isolates one
-method under the shared tuning pipeline while a system's score credits the
-whole package without attributing it to any one part.
+RelArena accommodates end-to-end systems through a separate contract instead
+of forcing them into the model tuning loop. Implement `RelArenaSystem` when the
+entry owns the complete procedure that produces its final predictions: its own
+hyperparameter search, training-budget selection, component choices, ensemble,
+or pretrained recipe. Register it with `@register_system`; systems do not
+declare a `SearchSpace`.
 
-What the flag does **not** change: a system still obeys every protocol rule in
-this document — the censored databases, the per-example timestamps, the
-leakage guards, the runtime policy, and the public label-free cache warmers.
-It only changes how the entry is reported: leaderboards and plots read
-`RelArenaModel.kind` (via `evaluation.method_kind`) to rank models alone, or
-both populations together with systems clearly marked.
+```python
+import numpy as np
+from relbench.base import EntityTask
 
-A parameter-free space does not by itself make a system: `constant-global` runs one
-config under the shared pipeline and stays a model. The test is whether the
+from relarena.dataset import InnerSplit, OuterSplit
+from relarena.registry import register_system
+from relarena.system import RelArenaSystem
+
+
+@register_system
+class MySystem(RelArenaSystem):
+    name = "mysystem"
+
+    def run(
+        self,
+        task: EntityTask,
+        *,
+        inner_split: InnerSplit,
+        outer_split: OuterSplit,
+        seed: int,
+        time_limit: float | None = None,
+    ) -> np.ndarray:
+        ...
+        return predictions  # aligned with outer_split.eval_table
+```
+
+The harness passes the actual split objects, not a separate system-input
+wrapper. A system usually uses `inner_split` to make its internal choices and
+`outer_split` to produce the reportable predictions, but the API does not
+prescribe that algorithm: a system may ignore the inner split.
+
+Systems and models are not the same kind of result. Both receive the same
+censored data and hidden-label test protocol, but a model's score isolates one
+method under the shared tuning pipeline while a system's score credits its
+whole procedure. A system therefore produces one `SystemResult` with final test
+metrics and total runtime. It does not produce fake configs, a placeholder
+validation score, or an `n_trials` value. Result frames mark the row with
+`kind="system"` so leaderboards can report models alone or both populations.
+
+A system still obeys the protocol boundaries: it only receives the censored
+databases in the split objects, `outer_split.eval_table` is masked, and the
+outer split contains no test labels. The framework validates the returned
+shape and owns final evaluation.
+
+#### Shared end-to-end runtime constraint
+
+Systems have the same runtime allowance as models. The current policy sets a
+24-hour ceiling for the complete run on the largest tasks, including
+preprocessing. Methods should not aim to exhaust that allowance; most methods
+finish in under 12 hours even on the largest tasks. For a model, the total
+covers every tuning trial, selection, final fit, and prediction. For a system,
+it covers all work used to produce the returned predictions, including internal
+search, component training, refitting, and ensembling. Moving selection inside
+`run` does not move it outside the runtime budget.
+
+`SystemResult.time_total` measures the call to `RelArenaSystem.run`. If a
+submission performs preprocessing separately through a public cache warmer,
+that time is reported and counted toward the same end-to-end allowance even
+though it is not part of `time_total`. The `time_limit` argument is a soft
+budget; a system must either honor it or document why its training loop cannot
+stop safely at an arbitrary wall-clock boundary. See
+[The tuning regime](tuning-regime.md) for the full runtime policy.
+
+The two execution paths are available directly as `run_model_experiment` and
+`run_system_experiment`. `run_experiment` is the shared dispatcher used by the
+CLI when it only has a registered method class.
+
+A parameter-free space does not by itself make a system: `constant-global` runs
+one config under the shared pipeline and stays a model. The test is whether the
 score can be attributed to the method itself under the harness's controls.
-
-**System support is experimental.** There is no dedicated system interface
-yet: a system implements the ordinary model API and works around it — the
-established tricks are running all of its tuning inside a single fit of the
-default config (register a space with empty `default_overrides` and nothing to
-sample) and carrying what the tuning phase chose over to the refit phase
-through module-level globals, since the harness constructs a fresh instance
-per phase and a parameter-free config cannot carry state. Both tricks impose
-real constraints (the phases must share a process, and `--n-trials` becomes a
-no-op), so **a system submission needs extra validation by and discussion with the maintainers**
-beyond the ordinary review checklist before it can land. A future release will
-replace these workarounds with an explicit fitting API for systems.
 
 ## 3. Tuning
 
@@ -424,9 +468,11 @@ uv run pre-commit run --all-files
 - [ ] Compute knobs (batch size, epochs, steps) fixed outside the space
 - [ ] `supported_task_types` narrowed if the model cannot do a task type
 - [ ] `refit_on_full_data` matches the method's published protocol
-- [ ] `kind = "system"` if selection happens inside `fit` rather than through
-      the registered space (see [Model or system?](#model-or-system))
-- [ ] Heavy imports inside `fit`; extra declared in `pyproject.toml`
+- [ ] Use `RelArenaSystem` + `@register_system` if the method owns its selection
+      (see [Model or system?](#model-or-system))
+- [ ] The complete model or system procedure stays within the shared runtime
+      allowance, including separately run preprocessing
+- [ ] Heavy imports inside `fit`, `predict`, or `run`; extra declared in `pyproject.toml`
 - [ ] Shared helpers in `_shared/`, not imported from a sibling model
 - [ ] Vendored code in `_vendor/` with docstring + `.coveragerc` + `NOTICE` + license text
 - [ ] Expensive CPU pre-processing goes through a public, label-free cache-warm

--- a/docs/predictive-task.md
+++ b/docs/predictive-task.md
@@ -239,7 +239,10 @@ Good starting points are `constant-global` (constant baseline), `lightgbm` (enti
 and the `tabpfn-rel` variants (cross-table features). RPI can run any compatible
 registered model; the package README is the
 [canonical model inventory](../README.md#models), including paper-facing and
-experimental registrations. `n_trials` controls the requested tuning
+local variants. End-to-end `RelArenaSystem` registrations target benchmark
+runs and are not accepted here: RPI fits once and predicts later at a
+caller-selected timestamp, which is a different lifecycle from a system's
+single split-to-predictions `run`. `n_trials` controls the requested tuning
 budget (`0` skips tuning and fits the default config); `seed` sets the RNG. Prefer
 `n_trials=0` for API runs unless repeated hosted fits are intentional.
 

--- a/docs/tuning-regime.md
+++ b/docs/tuning-regime.md
@@ -21,15 +21,15 @@ some critical progress that allows us for the first time to compare methods,
 while acknowledging the work that still has to be done to make them perfectly
 comparable.
 
-One deliberate exception to (a): entries registered as **systems**
-(`RelArenaModel.kind`, see
-[adding-a-model.md](adding-a-model.md#model-or-system)) run their own selection
-inside `fit` instead of the standardized tuning pipeline. They stay inside (b)
-— the same runtime policy applies — and inside every protocol rule (splits,
-censoring, leakage guards), so their final scores are fairly earned; what is
-lost is the attribution that (a) buys for models. Leaderboards keep the two
-populations separable rather than pretending a system's score isolates a
-method.
+One deliberate exception to (a): entries registered as **systems** implement
+`RelArenaSystem` (see
+[adding-a-model.md](adding-a-model.md#model-or-system)) and run their own
+selection inside `run` instead of the standardized tuning pipeline. They stay
+inside (b) — the same end-to-end runtime policy applies — and inside every
+protocol rule (splits, censoring, leakage guards), so their final scores are
+fairly earned; what is lost is the attribution that (a) buys for models.
+Leaderboards keep the two populations separable rather than pretending a
+system's score isolates a method.
 
 ## Why is (b) so hard?
 
@@ -100,12 +100,12 @@ larger search spaces for smaller tasks, this increase in size should be
 within reasonable bounds. Tuning your method for 24h on a `rel-f1` task is
 definitely not reasonable. Currently, all methods but `relgt` use a fixed-size
 search space per dataset, i.e. they don't adjust it to the dataset size. In
-general, nearly all methods do not actually hit the 24h constraint, with nearly all of
-them running for at most 12h of recorded runtime per task (excluding the
-cached pre-processing). Only `relgt` and `rt-plurel` currently break the 12h
-barrier, both excluding their pre-processing: `relgt` with up to 41h of pure
-GPU time on `rel-avito/user-visits`, and `rt-plurel` with up to 16.3h on the
-largest `rel-amazon` task.
+general, methods should not aim to exhaust the 24h allowance. Nearly all run
+for at most 12h of recorded runtime per task, even on the largest tasks
+(excluding cached pre-processing). Only `relgt` and `rt-plurel` currently break
+the 12h barrier, both excluding their pre-processing: `relgt` with up to 41h of
+pure GPU time on `rel-avito/user-visits`, and `rt-plurel` with up to 16.3h on
+the largest `rel-amazon` task.
 
 ## What we ran
 

--- a/src/relarena/__init__.py
+++ b/src/relarena/__init__.py
@@ -20,9 +20,20 @@ from relarena.checksums import (
 from relarena.dataset import InnerSplit, OuterSplit, RelBenchDatasetTask, Split
 from relarena.identity import RunIdentity
 from relarena.model import RelArenaModel
-from relarena.registry import ModelRegistry, register_model, registry
-from relarena.results import TrialResult, summary_to_dataframe
-from relarena.runner import run_experiment
+from relarena.registry import (
+    MethodRegistry,
+    ModelRegistry,
+    register_model,
+    register_system,
+    registry,
+)
+from relarena.results import SystemResult, TrialResult, summary_to_dataframe
+from relarena.runner import (
+    run_experiment,
+    run_model_experiment,
+    run_system_experiment,
+)
+from relarena.system import RelArenaSystem
 from relarena.tasks import RELBENCH_V1_DATASETS, TaskSpec, list_entity_tasks
 from relarena.tuner import tune
 
@@ -31,9 +42,12 @@ __all__ = [
     "CacheConfig",
     "CacheMiss",
     "RelArenaModel",
+    "RelArenaSystem",
     "RunIdentity",
     "ModelRegistry",
+    "MethodRegistry",
     "register_model",
+    "register_system",
     "registry",
     "RelBenchDatasetTask",
     "Split",
@@ -41,10 +55,13 @@ __all__ = [
     "OuterSplit",
     "TaskSpec",
     "TrialResult",
+    "SystemResult",
     "cache_key",
     "cached_artifact",
     "list_entity_tasks",
     "run_experiment",
+    "run_model_experiment",
+    "run_system_experiment",
     "summary_to_dataframe",
     "tune",
     "table_checksum",

--- a/src/relarena/cli.py
+++ b/src/relarena/cli.py
@@ -25,7 +25,7 @@ import pandas as pd
 import relarena.models  # noqa: F401  (registers built-in models)
 from relarena.registry import registry
 from relarena.results import summary_to_dataframe
-from relarena.runner import run_experiment
+from relarena.runner import SystemExperimentSummary, run_experiment
 from relarena.tasks import RELBENCH_V1_DATASETS, list_entity_tasks
 
 
@@ -109,16 +109,22 @@ def main(argv: list[str] | None = None) -> int:
             print(f"    ERROR: {exc!r}", file=sys.stderr)
             continue
         frames.append(summary_to_dataframe(summary))
-        best = summary.tuned or summary.default
-        if best is None or best.val_score is None:
-            print("    (no successful trial)")
+        if isinstance(summary, SystemExperimentSummary):
+            score = summary.result.test_score
+            score_str = f"{score:.4f}" if score is not None else "n/a"
+            print(f"    {summary.metric_name}: test={score_str}")
         else:
-            test_str = (
-                f"{best.test_score:.4f}" if best.test_score is not None else "n/a"
-            )
-            print(
-                f"    {summary.metric_name}: val={best.val_score:.4f} test={test_str}"
-            )
+            best = summary.tuned or summary.default
+            if best is None or best.val_score is None:
+                print("    (no successful trial)")
+            else:
+                test_str = (
+                    f"{best.test_score:.4f}" if best.test_score is not None else "n/a"
+                )
+                print(
+                    f"    {summary.metric_name}: val={best.val_score:.4f} "
+                    f"test={test_str}"
+                )
 
     if not frames:
         print("No successful runs.", file=sys.stderr)

--- a/src/relarena/evaluation/leaderboard.py
+++ b/src/relarena/evaluation/leaderboard.py
@@ -37,7 +37,7 @@ def to_bencheval_frame(results: pd.DataFrame) -> pd.DataFrame:
     - `metric_error` ← `to_metric_error(test_score, <primary metric>)`, using
       the per-row `metric` column (always a registered primary, never the
       auxiliary native-metric columns)
-    - `time_train_s` ← `fit_time_tuning + fit_time_refit`
+    - `time_train_s` ← model fit times, or a system's complete `time_total`
     - `time_infer_s` ← `predict_time_refit`
 
     Only the val-selected config per run contributes (one row per method/task);
@@ -54,6 +54,12 @@ def to_bencheval_frame(results: pd.DataFrame) -> pd.DataFrame:
         to_metric_error(score, metric)
         for score, metric in zip(rows["test_score"], rows["metric"], strict=True)
     ]
+
+    def seconds(column: str) -> pd.Series:
+        if column not in rows:
+            return pd.Series(0.0, index=rows.index)
+        return rows[column].fillna(0.0)
+
     frame = pd.DataFrame(
         {
             "method": rows["model"].to_numpy(),
@@ -62,9 +68,11 @@ def to_bencheval_frame(results: pd.DataFrame) -> pd.DataFrame:
             ).to_numpy(),
             "metric_error": metric_error,
             "time_train_s": (
-                rows["fit_time_tuning"].fillna(0.0) + rows["fit_time_refit"].fillna(0.0)
+                seconds("fit_time_tuning")
+                + seconds("fit_time_refit")
+                + seconds("time_total")
             ).to_numpy(),
-            "time_infer_s": rows["predict_time_refit"].fillna(0.0).to_numpy(),
+            "time_infer_s": seconds("predict_time_refit").to_numpy(),
         }
     )
     # A NaN primary score (e.g. roc_auc on a degenerate window) survives the
@@ -102,7 +110,7 @@ def method_kind(model: str) -> str:
     A system faces the same tasks, splits, metrics, and budget as every model —
     the comparison is fair on final performance — but selects its own
     hyperparameters or components inside `fit`, so its score credits the whole
-    package rather than isolating one method (see `RelArenaModel.kind`).
+    package rather than isolating one model (see `RelArenaSystem`).
     Unregistered names (reference baselines, retired methods) rank as models.
     """
     # Built-ins register on this import, which a leaderboard-only caller (load
@@ -113,7 +121,7 @@ def method_kind(model: str) -> str:
     from relarena.registry import registry
 
     try:
-        return registry.get(model).kind
+        return registry.kind(model)
     except KeyError:
         return "model"
 

--- a/src/relarena/model.py
+++ b/src/relarena/model.py
@@ -50,11 +50,9 @@ class RelArenaModel(ABC):
     #: protocol reports a best-val checkpoint rather than a train+val refit.
     refit_on_full_data: ClassVar[bool] = True
 
-    #: `"model"` (selection through the registered search space) or `"system"`
-    #: (selection inside `fit`). Leaderboards and plots read this to keep the
-    #: two populations separable — they are not the same kind of result. What
-    #: qualifies, the experimental status of system support, and the submission
-    #: rules live in docs/adding-a-model.md, "Model or system?".
+    #: Result category for models. Native systems implement `RelArenaSystem`;
+    #: this attribute remains for compatibility with older system adapters that
+    #: implemented the model contract.
     kind: ClassVar[str] = "model"
 
     def __init__(

--- a/src/relarena/registry.py
+++ b/src/relarena/registry.py
@@ -1,21 +1,33 @@
-"""Model registry.
+"""Model and system registry.
 
-A string-keyed registry pairing each model class with its hyperparameter
-`SearchSpace` (the search space lives *beside* the
-model, not on it — see `search_space.py`). Mirrors TabArena, where a model is
-bound to its config generator externally rather than declaring its own.
+A string-keyed registry for both method contracts. Model entries pair a class
+with its external `SearchSpace`; system entries need no search space because
+they own their complete prediction procedure.
 """
 
 from __future__ import annotations
 
-from typing import Callable, Iterator, Type
+from dataclasses import dataclass
+from typing import Callable, Iterator, Type, TypeAlias
 
 from relarena.model import RelArenaModel
 from relarena.search_space import SearchSpaceProvider
+from relarena.system import RelArenaSystem
+
+Method: TypeAlias = type[RelArenaModel] | type[RelArenaSystem]
 
 
-class ModelRegistry:
-    """A string-keyed collection of `(model class, search space)` entries.
+@dataclass(frozen=True)
+class RegistryEntry:
+    """One registered method and the harness metadata needed to run it."""
+
+    method_cls: Method
+    kind: str
+    search_space: SearchSpaceProvider | None = None
+
+
+class MethodRegistry:
+    """A string-keyed collection of model and system entries.
 
     The "search space" of an entry is a `SearchSpaceProvider` — a fixed
     `SearchSpace` or a factory the harness resolves per task (see
@@ -24,7 +36,7 @@ class ModelRegistry:
 
     def __init__(self) -> None:
         """Create an empty registry."""
-        self._entries: dict[str, tuple[Type[RelArenaModel], SearchSpaceProvider]] = {}
+        self._entries: dict[str, RegistryEntry] = {}
 
     def register(
         self, model_cls: Type[RelArenaModel], search_space: SearchSpaceProvider
@@ -38,50 +50,79 @@ class ModelRegistry:
         if not name:
             raise ValueError(f"{model_cls.__name__} must define a class-level `name`.")
         existing = self._entries.get(name)
-        if existing is not None and existing[0] is not model_cls:
+        if existing is not None and existing.method_cls is not model_cls:
             raise ValueError(
                 f"A different model is already registered under "
-                f"'{name}': {existing[0].__name__}"
+                f"'{name}': {existing.method_cls.__name__}"
             )
-        self._entries[name] = (model_cls, search_space)
+        # `kind` preserves compatibility with the experimental pre-system API.
+        # Native systems use `register_system` below.
+        kind = getattr(model_cls, "kind", "model")
+        self._entries[name] = RegistryEntry(model_cls, kind, search_space)
         return model_cls
 
-    def get(self, name: str) -> Type[RelArenaModel]:
-        """Return the model class registered under `name` (raises if unknown)."""
-        return self._entry(name)[0]
+    def register_system(self, system_cls: Type[RelArenaSystem]) -> Type[RelArenaSystem]:
+        """Register a native system, which has no harness search space."""
+        name = getattr(system_cls, "name", None)
+        if not name:
+            raise ValueError(f"{system_cls.__name__} must define a class-level `name`.")
+        existing = self._entries.get(name)
+        if existing is not None and existing.method_cls is not system_cls:
+            raise ValueError(
+                f"A different method is already registered under "
+                f"'{name}': {existing.method_cls.__name__}"
+            )
+        self._entries[name] = RegistryEntry(system_cls, "system")
+        return system_cls
+
+    def get(self, name: str) -> Method:
+        """Return the model or system class under `name` (raises if unknown)."""
+        return self._entry(name).method_cls
 
     def search_space(self, name: str) -> SearchSpaceProvider:
         """Return the search-space provider under `name` (raises if unknown)."""
-        return self._entry(name)[1]
+        entry = self._entry(name)
+        if entry.search_space is None:
+            raise TypeError(f"System '{name}' has no harness search space.")
+        return entry.search_space
 
     def search_space_for(self, model_cls: Type[RelArenaModel]) -> SearchSpaceProvider:
         """Return the search-space provider for `model_cls` (by its `name`)."""
         return self.search_space(model_cls.name)
 
+    def kind(self, name: str) -> str:
+        """Return `"model"` or `"system"` for the registered method."""
+        return self._entry(name).kind
+
     def names(self) -> list[str]:
-        """Return the registered model names, sorted."""
+        """Return the registered method names, sorted."""
         return sorted(self._entries)
 
-    def _entry(self, name: str) -> tuple[Type[RelArenaModel], SearchSpaceProvider]:
+    def _entry(self, name: str) -> RegistryEntry:
         if name not in self._entries:
-            raise KeyError(f"No model registered under '{name}'. Known: {self.names()}")
+            raise KeyError(
+                f"No method registered under '{name}'. Known: {self.names()}"
+            )
         return self._entries[name]
 
-    def __iter__(self) -> Iterator[Type[RelArenaModel]]:
-        """Iterate over the registered model classes."""
-        return (cls for cls, _ in self._entries.values())
+    def __iter__(self) -> Iterator[Method]:
+        """Iterate over the registered model and system classes."""
+        return (entry.method_cls for entry in self._entries.values())
 
     def __contains__(self, name: object) -> bool:
-        """Return whether a model is registered under `name`."""
+        """Return whether a method is registered under `name`."""
         return name in self._entries
 
     def __len__(self) -> int:
-        """Return the number of registered models."""
+        """Return the number of registered methods."""
         return len(self._entries)
 
 
-#: The default global registry. Models register into it via `@register_model`.
-registry = ModelRegistry()
+#: Backward-compatible name for the registry class.
+ModelRegistry = MethodRegistry
+
+#: The default global registry used by both registration decorators.
+registry = MethodRegistry()
 
 
 def register_model(
@@ -100,3 +141,27 @@ def register_model(
         return registry.register(model_cls, search_space)
 
     return decorator
+
+
+def register_system(
+    system_cls: Type[RelArenaSystem],
+) -> Type[RelArenaSystem]:
+    """Register a `RelArenaSystem` without a harness search space.
+
+    Usage::
+
+        @register_system
+        class MySystem(RelArenaSystem): ...
+    """
+    return registry.register_system(system_cls)
+
+
+__all__ = [
+    "Method",
+    "MethodRegistry",
+    "ModelRegistry",
+    "RegistryEntry",
+    "register_model",
+    "register_system",
+    "registry",
+]

--- a/src/relarena/results.py
+++ b/src/relarena/results.py
@@ -1,8 +1,7 @@
-"""Result schema.
+"""Model and system result schemas.
 
-A `TrialResult` is the atomic record: one config fit & evaluated on one
-`(task, seed)`. It stores configurations, metrics, **wall-clock times**, and
-optional predictions as useful metadata for downstream analysis.
+Models produce one `TrialResult` per harness-selected configuration. Systems
+produce one `SystemResult` for their complete internal procedure.
 """
 
 from __future__ import annotations
@@ -17,7 +16,7 @@ import numpy as np
 if TYPE_CHECKING:
     import pandas as pd
 
-    from relarena.runner import ExperimentSummary
+    from relarena.runner import ExperimentSummary, SystemExperimentSummary
 
 
 def config_id_for(config: dict[str, Any]) -> str:
@@ -72,6 +71,21 @@ class TrialResult:
         return self.error is None
 
 
+@dataclass
+class SystemResult:
+    """Outcome of one end-to-end system run.
+
+    Systems do not expose harness-selected configurations or validation scores.
+    Their complete internal procedure is represented by a final test result and
+    one total wall-clock time.
+    """
+
+    test_score: float | None = None
+    test_metrics: dict[str, float] = field(default_factory=dict)
+    time_total: float = 0.0
+    test_pred: np.ndarray | None = field(default=None, repr=False)
+
+
 #: Prediction-array fields dropped when flattening trials to a tidy DataFrame.
 #: The native-metric dicts (`val_metrics` / `test_metrics`) are *not* dropped
 #: — they're expanded into `val_<metric>` / `test_<metric>` columns.
@@ -105,6 +119,7 @@ def trials_to_dataframe(trials: list[TrialResult]) -> pd.DataFrame:
 _IDENTITY_COLS = (
     "id",
     "model",
+    "kind",
     "dataset",
     "task",
     "task_type",
@@ -115,22 +130,45 @@ _IDENTITY_COLS = (
 
 
 def summary_to_dataframe(
-    summary: ExperimentSummary,
+    summary: ExperimentSummary | SystemExperimentSummary,
     *,
     job_id: str | None = None,
 ) -> pd.DataFrame:
-    """One row per evaluated config (the full search), with identity columns.
+    """Flatten a model or system experiment into the shared results frame.
 
-    The single results schema shared by the `relarena` CLI and batch sweeps:
-    every trial keeps its native scores and all metrics (`val_<m>` /
-    `test_<m>`, from `trials_to_dataframe`) plus phase times; only the
-    val-selected config (`selected=True`) and the zero-tuning default carry a
-    refit `test_score`. The hyperparameter `config` is JSON-encoded for
-    portability. The run's identity (model/dataset/task/task_type/seed/n_trials/
-    metric) comes straight off the self-describing `summary`; `job_id` is a
-    batch run's cache key, omitted for in-process CLI runs (so the `id` column
-    is then absent).
+    Model summaries contain one row per trial, including config, validation
+    metrics, and phase timings. A system summary contains one selected row with
+    its final test metrics and `time_total`; it has no synthetic config,
+    validation score, or trial count. `job_id` is an optional batch cache key.
     """
+    import pandas as pd
+
+    # Import at call time to avoid a results ↔ runner import cycle.
+    from relarena.runner import SystemExperimentSummary
+
+    if isinstance(summary, SystemExperimentSummary):
+        result = summary.result
+        row: dict[str, Any] = {
+            "model": summary.system_name,
+            "kind": "system",
+            "dataset": summary.dataset,
+            "task": summary.task_name,
+            "task_type": summary.task_type.name,
+            "seed": summary.seed,
+            "metric": summary.metric_name,
+            "selected": True,
+            "test_score": result.test_score,
+            "time_total": result.time_total,
+        }
+        if job_id is not None:
+            row["id"] = job_id
+        row.update(
+            {f"test_{name}": value for name, value in result.test_metrics.items()}
+        )
+        front = [c for c in _IDENTITY_COLS if c in row] + ["selected"]
+        remaining = [key for key in row if key not in front]
+        return pd.DataFrame([{column: row[column] for column in front + remaining}])
+
     df = trials_to_dataframe(summary.trials)
     if "config" in df.columns:
         df["config"] = df["config"].map(
@@ -141,6 +179,7 @@ def summary_to_dataframe(
     if job_id is not None:
         df["id"] = job_id
     df["model"] = summary.model_name
+    df["kind"] = summary.kind
     df["dataset"] = summary.dataset
     df["task"] = summary.task_name
     df["task_type"] = summary.task_type.name

--- a/src/relarena/runner.py
+++ b/src/relarena/runner.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import logging
 import math
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Type
 
+import numpy as np
 from relbench.base import TaskType
 
 from relarena.cache import resolve_cache_config
@@ -21,8 +23,9 @@ from relarena.dataset import RelBenchDatasetTask
 from relarena.metrics import is_better
 from relarena.model import RelArenaModel
 from relarena.registry import registry
-from relarena.results import TrialResult
+from relarena.results import SystemResult, TrialResult
 from relarena.search_space import SearchSpaceProvider
+from relarena.system import RelArenaSystem
 from relarena.tasks import ENTITY_TASK_TYPES
 from relarena.tuner import refit_and_evaluate, tune
 
@@ -61,9 +64,104 @@ class ExperimentSummary:
     default: TrialResult | None  # the zero-tuning config
     tuned: TrialResult | None  # best config by validation score
     trials: list[TrialResult]  # all trials and their analysis metadata
+    kind: str = "model"
 
 
-def run_experiment(
+@dataclass
+class SystemExperimentSummary:
+    """The result for one end-to-end `(system, dataset, task, seed)` run."""
+
+    system_name: str
+    dataset: str
+    task_name: str
+    task_type: TaskType
+    metric_name: str
+    seed: int
+    result: SystemResult
+
+
+def run_system_experiment(
+    system_cls: Type[RelArenaSystem],
+    dataset_name: str,
+    task_name: str,
+    *,
+    seed: int = 0,
+    time_limit: float | None = None,
+    download: bool = True,
+    cache_predictions: bool = True,
+    cache_dir: str | Path | None = None,
+    evaluate_test: bool = True,
+) -> SystemExperimentSummary:
+    """Run one system with both protocol splits and record its final result.
+
+    RelArena constructs the correctly censored `InnerSplit` and `OuterSplit`
+    objects, withholds test labels, and evaluates the returned predictions. The
+    system owns every step between receiving the splits and returning those
+    predictions; in particular, it may use the inner split for selection or
+    ignore it.
+    """
+    source = RelBenchDatasetTask(dataset_name, task_name, download=download)
+    task = source.task
+    cache = resolve_cache_config(cache_dir, on_miss="raise")
+
+    assert task.task_type in ENTITY_TASK_TYPES, (
+        f"RelArena only handles regression and binary classification tasks; got "
+        f"{task.task_type} for task '{task_name}'."
+    )
+    if task.task_type not in system_cls.supported_task_types:
+        raise ValueError(
+            f"System '{system_cls.name}' does not support task_type "
+            f"{task.task_type} (task '{task_name}')."
+        )
+
+    inner = source.inner_split()
+    outer = source.outer_split()
+    system = system_cls(cache=cache, run_identity=source.run_identity())
+    started = time.perf_counter()
+    predictions = np.asarray(
+        system.run(
+            task,
+            inner_split=inner,
+            outer_split=outer,
+            seed=seed,
+            time_limit=time_limit,
+        )
+    )
+    time_total = time.perf_counter() - started
+    expected_shape = (len(outer.eval_table.df),)
+    if predictions.shape != expected_shape:
+        raise ValueError(
+            f"System '{system_cls.name}' returned predictions with shape "
+            f"{predictions.shape}; expected {expected_shape}."
+        )
+
+    metric = source.metric
+    test_metrics: dict[str, float] = {}
+    test_score = None
+    if evaluate_test:
+        metrics = list(task.metrics)
+        if metric.__name__ not in {m.__name__ for m in metrics}:
+            metrics.append(metric)
+        test_metrics = task.evaluate(predictions, None, metrics=metrics)
+        test_score = float(test_metrics[metric.__name__])
+
+    return SystemExperimentSummary(
+        system_name=system_cls.name,
+        dataset=dataset_name,
+        task_name=task_name,
+        task_type=task.task_type,
+        metric_name=metric.__name__,
+        seed=seed,
+        result=SystemResult(
+            test_score=test_score,
+            test_metrics=test_metrics,
+            time_total=time_total,
+            test_pred=predictions if cache_predictions else None,
+        ),
+    )
+
+
+def run_model_experiment(
     model_cls: Type[RelArenaModel],
     dataset_name: str,
     task_name: str,
@@ -78,7 +176,7 @@ def run_experiment(
     evaluate_test: bool = True,
     require_all_trials: bool = True,
 ) -> ExperimentSummary:
-    """Tune `model_cls` on one RelBench entity task and summarize the result.
+    """Tune one model on a RelBench entity task and summarize its trials.
 
     `search_space` defaults to the one registered for `model_cls` (via
     `@register_model`); pass it explicitly to override.
@@ -198,4 +296,58 @@ def run_experiment(
         default=default,
         tuned=tuned,
         trials=trials,
+        kind=getattr(model_cls, "kind", "model"),
+    )
+
+
+def run_experiment(
+    method_cls: Type[RelArenaModel] | Type[RelArenaSystem],
+    dataset_name: str,
+    task_name: str,
+    *,
+    search_space: SearchSpaceProvider | None = None,
+    seed: int = 0,
+    n_trials: int = 10,
+    time_limit_per_trial: float | None = None,
+    download: bool = True,
+    cache_predictions: bool = True,
+    cache_dir: str | Path | None = None,
+    evaluate_test: bool = True,
+    require_all_trials: bool = True,
+) -> ExperimentSummary | SystemExperimentSummary:
+    """Dispatch one experiment to the model or system runner.
+
+    Call `run_model_experiment` or `run_system_experiment` directly when the
+    method kind is already known. This wrapper keeps the CLI and registry-based
+    callers uniform. Model-only search arguments do not affect a native system;
+    `time_limit_per_trial` becomes its single soft time limit.
+    """
+    if isinstance(method_cls, type) and issubclass(method_cls, RelArenaSystem):
+        if search_space is not None:
+            raise TypeError("A RelArenaSystem does not have a harness search space.")
+        return run_system_experiment(
+            method_cls,
+            dataset_name,
+            task_name,
+            seed=seed,
+            time_limit=time_limit_per_trial,
+            download=download,
+            cache_predictions=cache_predictions,
+            cache_dir=cache_dir,
+            evaluate_test=evaluate_test,
+        )
+
+    return run_model_experiment(
+        method_cls,
+        dataset_name,
+        task_name,
+        search_space=search_space,
+        seed=seed,
+        n_trials=n_trials,
+        time_limit_per_trial=time_limit_per_trial,
+        download=download,
+        cache_predictions=cache_predictions,
+        cache_dir=cache_dir,
+        evaluate_test=evaluate_test,
+        require_all_trials=require_all_trials,
     )

--- a/src/relarena/system.py
+++ b/src/relarena/system.py
@@ -1,0 +1,63 @@
+"""The system contract.
+
+A system owns its complete prediction procedure. Unlike a `RelArenaModel`, it
+is not instantiated once per harness-selected configuration: the harness gives
+one instance both protocol splits and records the final predictions it returns.
+The system may use the inner split for selection in any way it chooses, or not
+use it at all.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+import numpy as np
+from relbench.base import EntityTask, TaskType
+
+from relarena.cache import CacheConfig
+from relarena.dataset import InnerSplit, OuterSplit
+from relarena.identity import RunIdentity
+from relarena.tasks import ENTITY_TASK_TYPES
+
+
+class RelArenaSystem(ABC):
+    """Base contract for an end-to-end relational prediction system."""
+
+    #: Unique, human-readable identifier used in the registry and result tables.
+    name: ClassVar[str]
+
+    #: Task types this system can handle.
+    supported_task_types: ClassVar[frozenset[TaskType]] = ENTITY_TASK_TYPES
+
+    def __init__(
+        self,
+        *,
+        cache: CacheConfig | None = None,
+        run_identity: RunIdentity | None = None,
+    ) -> None:
+        """Instantiate one system for one complete experiment."""
+        self.cache = cache or CacheConfig(directory=None, on_miss="compute")
+        self.run_identity = run_identity
+
+    @abstractmethod
+    def run(
+        self,
+        task: EntityTask,
+        *,
+        inner_split: InnerSplit,
+        outer_split: OuterSplit,
+        seed: int,
+        time_limit: float | None = None,
+    ) -> np.ndarray:
+        """Return predictions aligned with `outer_split.eval_table`.
+
+        The system owns everything needed to produce those predictions,
+        including any selection, refitting, ensembling, or pretrained recipe.
+        `inner_split` is available for selection but using it is not required.
+        Both split objects carry their correctly censored database states, and
+        `outer_split` contains no test labels.
+        """
+
+
+__all__ = ["RelArenaSystem"]

--- a/src/relarena/userdb/query.py
+++ b/src/relarena/userdb/query.py
@@ -33,6 +33,7 @@ from relarena.model import RelArenaModel
 from relarena.registry import registry
 from relarena.runner import select_best
 from relarena.search_space import TaskStats, resolve_search_space
+from relarena.system import RelArenaSystem
 from relarena.tuner import tune as run_tuning
 from relarena.userdb._schema import load_schema, validate
 from relarena.userdb.ingest import DatabaseSpec, build_dataset
@@ -122,6 +123,12 @@ class PredictiveQuery:
         self._warn_schema_only_cache(cache)
         self._cache = cache
         model_cls = registry.get(model)
+        if isinstance(model_cls, type) and issubclass(model_cls, RelArenaSystem):
+            raise TypeError(
+                f"'{model}' is a RelArenaSystem. PredictiveQuery requires a "
+                "RelArenaModel because it fits once and predicts at a later, "
+                "caller-selected timestamp."
+            )
         search_space = registry.search_space(model)
 
         # fill: on a custom DB the store starts empty, so build it as we go (the

--- a/tests/evaluation/test_leaderboard.py
+++ b/tests/evaluation/test_leaderboard.py
@@ -109,6 +109,27 @@ def test__to_bencheval_frame__dense_matrix__passes_bencheval_verify_data() -> No
     assert len(out) == 2  # one ranked row per method
 
 
+def test__to_bencheval_frame__system_total_time__is_preserved() -> None:
+    results = pd.DataFrame(
+        [
+            {
+                "model": "a-system",
+                "dataset": "rel-f1",
+                "task": "driver-dnf",
+                "metric": "roc_auc",
+                "selected": True,
+                "test_score": 0.9,
+                "time_total": 12.5,
+            }
+        ]
+    )
+
+    row = to_bencheval_frame(results).iloc[0]
+
+    assert row["time_train_s"] == pytest.approx(12.5)
+    assert row["time_infer_s"] == pytest.approx(0.0)
+
+
 def test__compute_leaderboard__dense_results__ranks_by_normalized_loss() -> None:
     pytest.importorskip("bencheval.evaluator")
     # constant-global is worst on both tasks, lightgbm best -> lightgbm ranks first.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ or trains.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pandas as pd
@@ -16,8 +17,8 @@ import pytest
 from relbench.base import TaskType
 
 from relarena import cli
-from relarena.results import TrialResult
-from relarena.runner import ExperimentSummary
+from relarena.results import SystemResult, TrialResult, summary_to_dataframe
+from relarena.runner import ExperimentSummary, SystemExperimentSummary
 from relarena.tasks import TaskSpec
 
 
@@ -90,6 +91,14 @@ def test__cli__successful_runs__writes_all_metrics_for_every_config(
     assert selected["test_roc_auc"].iloc[0] == pytest.approx(0.88)
 
 
+def test__summary_to_dataframe__preserves_legacy_adapter_system_kind() -> None:
+    summary = replace(_summary(), kind="system")
+
+    frame = summary_to_dataframe(summary)
+
+    assert set(frame["kind"]) == {"system"}
+
+
 def test__cli__no_successful_runs__returns_nonzero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -117,3 +126,34 @@ def test__cli__cache_dir__is_forwarded_to_runner(
     monkeypatch.setattr(cli, "run_experiment", run)
     assert cli.main(["--model", "constant-global", "--cache-dir", str(tmp_path)]) == 0
     assert seen["cache_dir"] == str(tmp_path)
+
+
+def test__cli__system_summary__writes_native_system_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec = TaskSpec("rel-f1", "driver-dnf", TaskType.BINARY_CLASSIFICATION)
+    monkeypatch.setattr(cli, "list_entity_tasks", lambda datasets: [spec])
+    summary = SystemExperimentSummary(
+        system_name="rt-plurel",
+        dataset="rel-f1",
+        task_name="driver-dnf",
+        task_type=TaskType.BINARY_CLASSIFICATION,
+        metric_name="roc_auc",
+        seed=0,
+        result=SystemResult(
+            test_score=0.9,
+            test_metrics={"roc_auc": 0.9},
+            time_total=12.0,
+        ),
+    )
+    monkeypatch.setattr(cli, "run_experiment", lambda *a, **k: summary)
+
+    out = tmp_path / "results.csv"
+    assert cli.main(["--model", "rt-plurel", "--output", str(out)]) == 0
+
+    row = pd.read_csv(out).iloc[0]
+    assert row["kind"] == "system"
+    assert row["time_total"] == pytest.approx(12.0)
+    assert row["selected"]
+    assert "config" not in row.index
+    assert "val_score" not in row.index

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import numpy as np
 import pytest
 from relbench.base import TaskType
 from relbench.metrics import roc_auc
@@ -18,6 +19,7 @@ from relarena import runner
 from relarena.cache import CacheConfig
 from relarena.identity import RunIdentity
 from relarena.results import TrialResult
+from relarena.system import RelArenaSystem
 
 _MODEL = SimpleNamespace(
     name="stub", supported_task_types=frozenset({TaskType.BINARY_CLASSIFICATION})
@@ -94,12 +96,12 @@ def refit_tags(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
 
 def _run(**kwargs: Any) -> Any:
-    return runner.run_experiment(
+    return runner.run_model_experiment(
         _MODEL, "rel-f1", "driver-dnf", search_space=object(), download=False, **kwargs
     )
 
 
-def test__run_experiment__a_trial_errored__raises_without_refitting(
+def test__run_model_experiment__a_trial_errored__raises_without_refitting(
     refit_tags: list[str],
 ) -> None:
     with pytest.raises(RuntimeError, match="1 of 2 trials failed"):
@@ -107,7 +109,7 @@ def test__run_experiment__a_trial_errored__raises_without_refitting(
     assert refit_tags == []  # the outer experiment never started
 
 
-def test__run_experiment__require_all_trials_off__refits_the_surviving_config(
+def test__run_model_experiment__require_all_trials_off__refits_the_surviving_config(
     refit_tags: list[str],
 ) -> None:
     summary = _run(require_all_trials=False)
@@ -116,7 +118,7 @@ def test__run_experiment__require_all_trials_off__refits_the_surviving_config(
     assert summary.tuned is not None and summary.tuned.test_score == 0.75
 
 
-def test__run_experiment__cache_dir__passes_one_resolved_config(
+def test__run_model_experiment__cache_dir__passes_one_resolved_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = SimpleNamespace(
@@ -133,7 +135,7 @@ def test__run_experiment__cache_dir__passes_one_resolved_config(
         return [_trial("default")]
 
     monkeypatch.setattr(runner, "tune", tune)
-    runner.run_experiment(
+    runner.run_model_experiment(
         _MODEL,
         "rel-f1",
         "driver-dnf",
@@ -143,3 +145,106 @@ def test__run_experiment__cache_dir__passes_one_resolved_config(
         cache_dir=tmp_path,
     )
     assert seen == [(CacheConfig(tmp_path, "raise"), _IDENTITY.for_phase("inner"))]
+
+
+def test__run_experiment__model_dispatches_to_model_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = object()
+    seen: dict[str, Any] = {}
+
+    def run_model(*args: Any, **kwargs: Any) -> object:
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return expected
+
+    monkeypatch.setattr(runner, "run_model_experiment", run_model)
+
+    actual = runner.run_experiment(
+        _MODEL,
+        "rel-f1",
+        "driver-dnf",
+        search_space=object(),
+        n_trials=3,
+        download=False,
+    )
+
+    assert actual is expected
+    assert seen["args"] == (_MODEL, "rel-f1", "driver-dnf")
+    assert seen["kwargs"]["n_trials"] == 3
+
+
+def _system_source() -> SimpleNamespace:
+    task = SimpleNamespace(
+        task_type=TaskType.BINARY_CLASSIFICATION,
+        metrics=[roc_auc],
+        evaluate=lambda pred, target, metrics: {"roc_auc": 0.75},
+    )
+    outer = SimpleNamespace(eval_table=SimpleNamespace(df=[{}, {}, {}]))
+    return SimpleNamespace(
+        task=task,
+        metric=roc_auc,
+        inner_split=lambda: "inner",
+        outer_split=lambda: outer,
+        run_identity=lambda phase=None: _IDENTITY.for_phase(phase),
+    )
+
+
+def test__run_system_experiment__passes_both_splits_and_records_one_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _system_source()
+    monkeypatch.setattr(runner, "RelBenchDatasetTask", lambda *a, **k: source)
+    seen: dict[str, Any] = {}
+
+    class S(RelArenaSystem):
+        name = "system"
+
+        def run(self, task: Any, **kwargs: Any) -> np.ndarray:
+            seen.update(kwargs)
+            seen["identity"] = self.run_identity
+            return np.array([0.1, 0.2, 0.3])
+
+    summary = runner.run_system_experiment(
+        S, "rel-f1", "driver-dnf", seed=4, download=False
+    )
+
+    assert seen["inner_split"] == "inner"
+    assert seen["outer_split"] is source.outer_split()
+    assert seen["seed"] == 4
+    assert seen["identity"] == _IDENTITY
+    assert summary.result.test_score == pytest.approx(0.75)
+    assert summary.result.test_pred is not None
+    assert summary.result.test_pred.tolist() == [0.1, 0.2, 0.3]
+
+
+def test__run_experiment__native_system_dispatches_without_search_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _system_source()
+    monkeypatch.setattr(runner, "RelBenchDatasetTask", lambda *a, **k: source)
+
+    class S(RelArenaSystem):
+        name = "system"
+
+        def run(self, *args: Any, **kwargs: Any) -> np.ndarray:
+            return np.zeros(3)
+
+    summary = runner.run_experiment(S, "rel-f1", "driver-dnf", download=False)
+
+    assert isinstance(summary, runner.SystemExperimentSummary)
+
+
+def test__run_system_experiment__wrong_prediction_shape__raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runner, "RelBenchDatasetTask", lambda *a, **k: _system_source())
+
+    class S(RelArenaSystem):
+        name = "system"
+
+        def run(self, *args: Any, **kwargs: Any) -> np.ndarray:
+            return np.zeros((3, 1))
+
+    with pytest.raises(ValueError, match=r"expected \(3,\)"):
+        runner.run_system_experiment(S, "rel-f1", "driver-dnf", download=False)

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -15,6 +15,7 @@ from relarena.model import RelArenaModel
 from relarena.registry import ModelRegistry
 from relarena.results import TrialResult, config_id_for, trials_to_dataframe
 from relarena.search_space import SearchSpace
+from relarena.system import RelArenaSystem
 
 
 def test_metric_direction() -> None:
@@ -79,9 +80,31 @@ def test_registry_rejects_duplicate_name() -> None:
         reg.register(B, SearchSpace(default_overrides={}))
 
 
+def test_registry_registers_system_without_search_space() -> None:
+    reg = ModelRegistry()
+
+    class S(RelArenaSystem):
+        name = "s"
+
+        def run(self, *a, **k) -> np.ndarray:
+            return np.zeros(1)
+
+    reg.register_system(S)
+
+    assert reg.get("s") is S
+    assert reg.kind("s") == "system"
+    with pytest.raises(TypeError, match="no harness search space"):
+        reg.search_space("s")
+
+
 def test_abstract_model_cannot_be_instantiated() -> None:
     with pytest.raises(TypeError):
         RelArenaModel()
+
+
+def test_abstract_system_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError):
+        RelArenaSystem()
 
 
 def test__refit_on_full_data__defaults_true_and_is_overridable() -> None:


### PR DESCRIPTION
## Summary

- Add a first-class `RelArenaSystem.run` contract that receives the real `InnerSplit` and `OuterSplit` objects and returns final test predictions.
- Register systems without a search space and keep `run_model_experiment` and `run_system_experiment` as explicit execution paths behind the shared `run_experiment` dispatcher.
- Add native `SystemResult` and `SystemExperimentSummary` schemas with final metrics and total runtime, without synthetic configs, validation scores, or trial counts.
- Preserve the registered method kind when serializing legacy adapter summaries, fixing the system rows called out by Cursor Bugbot.
- Teach the CLI and leaderboard adapter to consume both result types, document the RPI model-only lifecycle boundary, and apply the same end-to-end runtime policy to models and systems. The existing 24h allowance is a ceiling rather than a target; most methods stay under 12h even on the largest tasks.

## Test plan

- `uv run ruff format --check .`
- `uv run ruff check .`
- `OMP_NUM_THREADS=1 uv run pytest -q` (407 passed, 23 skipped on the stack tip)

Stack 1 of 2. #23 migrates RT-PluRel onto this API.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
