### PR TITLE
Group dfs2sql temp-table statements per join path

### DIFF
--- a/src/relarena/featurization/dfs.py
+++ b/src/relarena/featurization/dfs.py
@@ -541,6 +541,8 @@ def build_dfs_features(
     from fastdfs.dfs import dfs_feature_column_name, get_dfs_engine
     from fastdfs.utils.type_utils import safe_convert_to_string
 
+    from relarena.featurization.dfs2sql_grouped import GROUPED_DFS2SQL_ENGINE
+
     cache = cache or CacheConfig(directory=None, on_miss="compute")
 
     entity_table = db.table_dict[task.entity_table]
@@ -586,7 +588,9 @@ def build_dfs_features(
     # matrix is built; only the computed frames outlive this block.
     with tempfile.TemporaryDirectory(prefix="relarena_dfs_") as engine_dir:
         cfg = DFSConfig(
-            max_depth=max_depth, engine_path=str(Path(engine_dir) / "dfs.db")
+            max_depth=max_depth,
+            engine=GROUPED_DFS2SQL_ENGINE,
+            engine_path=str(Path(engine_dir) / "dfs.db"),
         )
 
         def _compute_matrix() -> pd.DataFrame:

--- a/src/relarena/featurization/dfs2sql_grouped.py
+++ b/src/relarena/featurization/dfs2sql_grouped.py
@@ -1,0 +1,144 @@
+"""A dfs2sql engine that builds each set of cutoff-time temp tables once.
+
+fastdfs' stock `dfs2sql` engine names its intermediate cutoff-time tables per
+(table, depth), not per feature, so every feature on the same join path emits the
+same `CREATE TABLE AS` statements and drops them again right after its `SELECT`.
+On a wide task that is thousands of statements where a few hundred suffice.
+
+The engine here runs the stock SQL generator unchanged and regroups its output:
+each distinct set of temp tables is created once, every feature over it is
+selected, and only then is it dropped. Feature values and column order match the
+stock engine; only the statement order and count differ.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import uuid
+from pathlib import Path
+
+import featuretools as ft
+import pandas as pd
+from fastdfs import RDB
+from fastdfs.dfs import DFSConfig, assemble_dfs2sql_feature_frames, dfs_engine
+from fastdfs.dfs.dfs2sql_engine import DFS2SQLEngine
+from fastdfs.dfs.duckdb_database import DuckDBBuilder
+from fastdfs.dfs.gen_sqls import decode_column_from_sql, features2sql
+from sqlglot.expressions import Create, Drop, Expression, Select
+
+#: Engine name to pass as `DFSConfig(engine=...)`.
+GROUPED_DFS2SQL_ENGINE = "dfs2sql-grouped"
+
+
+def group_temp_table_statements(statements: list[Expression]) -> list[Expression]:
+    """Reorder stock dfs2sql statements so each set of temp tables is built once.
+
+    The stock generator emits `[CREATE..., SELECT, DROP...]` per feature. Features
+    whose CREATE statements render to the same SQL are moved next to each other and
+    share one CREATE/DROP pair. Selects without a CREATE (the no-cutoff path) pass
+    through in their original order. The `Select` objects are returned as is, so
+    callers can map results back by identity.
+    """
+    groups: dict[tuple[str, ...], dict[str, list[Expression]]] = {}
+    pending_creates: list[Expression] = []
+    current: dict[str, list[Expression]] | None = None
+    current_is_new = False
+    for statement in statements:
+        if isinstance(statement, Create):
+            pending_creates.append(statement)
+        elif isinstance(statement, Select):
+            key = tuple(create.sql() for create in pending_creates)
+            current_is_new = key not in groups
+            current = groups.setdefault(
+                key, {"creates": pending_creates, "selects": [], "drops": []}
+            )
+            current["selects"].append(statement)
+            pending_creates = []
+        elif isinstance(statement, Drop):
+            if current is None:
+                raise ValueError("DROP before any SELECT in dfs2sql statements")
+            if current_is_new:
+                current["drops"].append(statement)
+        else:
+            raise TypeError(f"unexpected dfs2sql statement: {type(statement).__name__}")
+    if pending_creates:
+        raise ValueError("trailing CREATE without a SELECT in dfs2sql statements")
+
+    ordered: list[Expression] = []
+    for group in groups.values():
+        ordered.extend(group["creates"])
+        ordered.extend(group["selects"])
+        ordered.extend(group["drops"])
+    return ordered
+
+
+@dfs_engine
+class GroupedDFS2SQLEngine(DFS2SQLEngine):
+    """The stock dfs2sql engine with temp-table statements grouped per join path."""
+
+    name = GROUPED_DFS2SQL_ENGINE
+
+    def compute_feature_matrix(
+        self,
+        rdb: RDB,
+        target_dataframe: pd.DataFrame,
+        key_mappings: dict[str, str],
+        cutoff_time_column: str | None,
+        features: list[ft.FeatureBase],
+        config: DFSConfig,
+    ) -> pd.DataFrame:
+        """Run the grouped statements and assemble the frames in feature order."""
+        target_index = "__target_index__"
+        engine_path = config.engine_path
+        if engine_path is None:
+            engine_path = str(
+                Path(tempfile.gettempdir()) / f"fastdfs_{uuid.uuid4()}.db"
+            )
+        builder = DuckDBBuilder(Path(engine_path))
+        self._build_database_tables(
+            builder, rdb, target_dataframe, target_index, cutoff_time_column
+        )
+
+        has_cutoff_time = config.use_cutoff_time and cutoff_time_column is not None
+        cutoff_time_col_name = builder.cutoff_time_col_name if has_cutoff_time else None
+        statements = features2sql(
+            features,
+            target_index,
+            has_cutoff_time=has_cutoff_time,
+            cutoff_time_table_name=(
+                builder.cutoff_time_table_name if has_cutoff_time else None
+            ),
+            cutoff_time_col_name=cutoff_time_col_name,
+            time_col_mapping=builder.time_columns if has_cutoff_time else None,
+            column_type_map=self._build_column_type_map(rdb, target_dataframe),
+            include_cutoff_time=config.include_cutoff_time,
+        )
+
+        # Grouping reorders the selects; restore the generator's feature order so
+        # the matrix columns come out as the stock engine emits them.
+        position = {id(s): i for i, s in enumerate(statements) if isinstance(s, Select)}
+        frames: list[tuple[int, pd.DataFrame]] = []
+        for statement in group_temp_table_statements(statements):
+            result = builder.db.sql(statement.sql())
+            if result is None:  # CREATE and DROP return nothing
+                continue
+            frame = result.df()
+            if cutoff_time_col_name in frame.columns:
+                frame = frame.drop(columns=[cutoff_time_col_name])
+            frame = frame.rename(columns=decode_column_from_sql)
+            frames.append((position[id(statement)], frame))
+        frames.sort(key=lambda item: item[0])
+
+        if not frames:
+            return pd.DataFrame({target_index: target_dataframe[target_index]})
+        canonical_index = pd.Index(
+            target_dataframe[target_index].values, name=target_index
+        )
+        merged = assemble_dfs2sql_feature_frames(
+            [frame for _, frame in frames],
+            target_index,
+            canonical_index,
+            concat_chunk_size=config.dfs2sql_concat_chunk_size,
+        )
+        passthrough = set(target_dataframe.columns) - {target_index}
+        return merged[[c for c in merged.columns if c not in passthrough]]

--- a/tests/featurization/test_dfs2sql_grouped.py
+++ b/tests/featurization/test_dfs2sql_grouped.py
@@ -1,0 +1,112 @@
+"""Tests for the grouped dfs2sql engine (no data download)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from sqlglot import parse_one
+
+pytest.importorskip("fastdfs")
+
+from fastdfs import DFSConfig, compute_dfs_features  # noqa: E402
+from fastdfs.utils.type_utils import safe_convert_to_string  # noqa: E402
+
+import relarena.featurization.dfs as dfs_mod  # noqa: E402
+import relarena.featurization.dfs2sql_grouped as grouped_mod  # noqa: E402
+from relarena.featurization.dfs2sql_grouped import (  # noqa: E402
+    GROUPED_DFS2SQL_ENGINE,
+    group_temp_table_statements,
+)
+from tests.featurization.test_dfs import _label_table, _toy_db, _toy_task  # noqa: E402
+
+
+def _stock_chunk(create_names: list[str], select: str) -> list:
+    """One feature's worth of stock output: creates, the select, the drops."""
+    creates = [parse_one(f"CREATE TABLE {n} AS SELECT 1") for n in create_names]
+    drops = [parse_one(f"DROP TABLE {n}") for n in create_names]
+    return [*creates, parse_one(select), *drops]
+
+
+def test__group_temp_table_statements__shared_creates__built_once() -> None:
+    a1, a2, b = "SELECT 1 AS a1", "SELECT 2 AS a2", "SELECT 3 AS b"
+    statements = [
+        *_stock_chunk(["t0", "t1"], a1),
+        *_stock_chunk(["t0", "t2"], b),
+        *_stock_chunk(["t0", "t1"], a2),
+    ]
+
+    grouped = group_temp_table_statements(statements)
+
+    assert [s.sql() for s in grouped] == [
+        "CREATE TABLE t0 AS SELECT 1",
+        "CREATE TABLE t1 AS SELECT 1",
+        a1,
+        a2,
+        "DROP TABLE t0",
+        "DROP TABLE t1",
+        "CREATE TABLE t0 AS SELECT 1",
+        "CREATE TABLE t2 AS SELECT 1",
+        b,
+        "DROP TABLE t0",
+        "DROP TABLE t2",
+    ]
+    # The select objects are passed through, so results map back by identity.
+    selects = [s for s in statements if s.sql().startswith("SELECT")]
+    assert [s for s in grouped if s.sql().startswith("SELECT")] == [
+        selects[0],
+        selects[2],
+        selects[1],
+    ]
+
+
+def test__group_temp_table_statements__no_creates__unchanged() -> None:
+    statements = [parse_one("SELECT 1"), parse_one("SELECT 2")]
+
+    assert group_temp_table_statements(statements) == statements
+
+
+def test__group_temp_table_statements__unexpected_statement__raises() -> None:
+    with pytest.raises(TypeError, match="Insert"):
+        group_temp_table_statements([parse_one("INSERT INTO t VALUES (1)")])
+
+
+def _dfs_input() -> pd.DataFrame:
+    df = _label_table([1, 2, 3], ts=["2021-06-01", "2020-02-15", "2021-06-01"]).df
+    df = df.drop(columns=["y"])
+    df["uid"] = safe_convert_to_string(df["uid"])
+    return df
+
+
+def _compute(engine: str, engine_path: Path) -> pd.DataFrame:
+    # A fresh RDB per call: `prepare_features` mutates the one it runs on.
+    rdb = dfs_mod._transform_rdb(dfs_mod._build_rdb(_toy_db()))
+    task = _toy_task()
+    return compute_dfs_features(
+        rdb,
+        _dfs_input(),
+        key_mappings={task.entity_col: f"{task.entity_table}.uid"},
+        cutoff_time_column=task.time_col,
+        config=DFSConfig(max_depth=2, engine=engine, engine_path=str(engine_path)),
+    )
+
+
+def test__grouped_engine__matches_stock_engine_and_issues_fewer_statements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    counts: dict[str, int] = {}
+    regroup = group_temp_table_statements
+
+    def spy(statements: list) -> list:
+        grouped = regroup(statements)
+        counts["stock"], counts["grouped"] = len(statements), len(grouped)
+        return grouped
+
+    monkeypatch.setattr(grouped_mod, "group_temp_table_statements", spy)
+
+    stock = _compute("dfs2sql", tmp_path / "stock.db")
+    grouped = _compute(GROUPED_DFS2SQL_ENGINE, tmp_path / "grouped.db")
+
+    pd.testing.assert_frame_equal(grouped, stock)
+    assert counts["grouped"] < counts["stock"]


### PR DESCRIPTION
Generated by Claude Code

Adds a `dfs2sql-grouped` DFS engine and selects it in `build_dfs_features`.

fastdfs' stock `dfs2sql` engine names its cutoff-time temp tables per `(table, depth)`, not per feature, so every feature on the same join path emits the same `CREATE TABLE AS` statements and drops them again right after its `SELECT`. The new engine runs the stock SQL generator unchanged and regroups its output: each distinct set of temp tables is created once, every feature over it is selected, and only then is it dropped. Selects run out of order, but the result frames are sorted back, so values and column order match the stock engine. No cache key changes.

On `rel-trial/study-adverse` this takes the statement count from 3353 to 945. On matched hardware across 13 RelBench tasks the DFS warm was 1.6x to 5.2x faster, never slower, with output equal to the stock engine within DuckDB's parallel-aggregation noise.

<details><summary>Design notes</summary>

- fastdfs exposes a `dfs_engine` registry, so this is a subclass overriding `compute_feature_matrix`, not a fork or a vendored copy.
- The regroup works on the statement list alone (`Create` / `Select` / `Drop`), so it does not touch the generator's private feature-block API.
- The engine is always on; there is no stock-vs-grouped knob because nothing would use it.
- Not included: hoisting the depth-0 target CTAS out of the loop. Measured alone it was worth under 2%, and grouping already cuts those statements by the group ratio.

</details>

<details><summary>Tests</summary>

`tests/featurization/test_dfs2sql_grouped.py`: the regroup on hand-built statements (shared creates built once, select identity preserved, no-create input unchanged, unexpected statement raises), and an end-to-end check that the grouped and stock engines return an identical frame on the toy database with fewer statements.

Full suite: 429 passed, 6 skipped, 1 failed. The failure is `tests/models/rt/test_model.py` with a torch sharing-strategy error on macOS that also fails on unmodified `main`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYEGLc6ntfC3j9YxtG2xpT
