### PR TITLE
Document the fork setup for model submissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ uv build
 ```
 
 For model integrations, follow [docs/adding-a-model.md](docs/adding-a-model.md).
+Open the pull request from a fork owned by your personal account with **Allow
+edits from maintainers** enabled, so maintainers can push rerun results to your
+branch (see [Submitting](docs/adding-a-model.md#10-submitting)).
 Keep optional dependencies lazy, document provenance for adapted or vendored
 code, and include focused tests. By contributing, you agree that your changes
 are licensed under this repository's Apache-2.0 license.

--- a/docs/adding-a-model.md
+++ b/docs/adding-a-model.md
@@ -479,6 +479,24 @@ uv run pre-commit run --all-files
       script
 - [ ] `tests/mymodel/{__init__,test_model}.py`
 - [ ] `uv run pre-commit run --all-files` clean, from the repo root
+- [ ] Pull request opened from a fork owned by a personal account, with
+      **Allow edits from maintainers** enabled (see [Submitting](#10-submitting))
+
+## 10. Submitting
+
+This is the submission process for now; it may change as the benchmark matures.
+
+Open the pull request with the implementation, docs, and tests only. Leave
+`baseline_results/` untouched: maintainers rerun every submitted method on
+fixed hardware, push the resulting rows to your branch, and merge once you have
+confirmed the numbers.
+
+For maintainers to push to your branch, the pull request must come from a fork
+owned by a **personal account**, with **Allow edits from maintainers** enabled
+in the pull request sidebar. GitHub does not offer that option for forks owned
+by an organization; a pull request from an organization fork forces the results
+through a separate pull request against your fork and a manual merge on your
+side.
 
 ## Appendix — what every existing model chose
 


### PR DESCRIPTION
Adds a "Submitting" section to `docs/adding-a-model.md` and a pointer in `CONTRIBUTING.md`.

Submitters open the PR with code, docs, and tests only. Maintainers rerun the method on fixed hardware and push the result rows to the PR branch. For that push to work, the PR must come from a fork owned by a personal account with **Allow edits from maintainers** enabled. GitHub does not offer that option on organization-owned forks, which forced a separate PR against the fork and a manual merge for a recent submission.

The section states that this process is current and may change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)