### PR TITLE
Add funding acknowledgements to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,9 +655,9 @@ Access call.
 This work was supported by European Union's Horizon Europe research and innovation programme
 under grant agreement number 101214398 (ELLIOT).
 
-**Disclaimer:** *Funded by the European Union. Views and opinions expressed are however those of
+**Disclaimer:** Funded by the European Union. Views and opinions expressed are however those of
 the author(s) only and do not necessarily reflect those of the European Union or the European
 Commission. Neither the European Union nor the European Commission can be held responsible for
-them.*
+them.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -644,3 +644,19 @@ RPI, please cite:
 RelArena-α redistributes no data, retrieving every database at runtime through
 [RelBench](https://github.com/snap-stanford/relbench), so please also cite RelBench when you
 report results on these tasks.
+
+<details>
+<summary><b>🙏 Acknowledgements</b> — EuroHPC LUMI and the EU-funded ELLIOT project</summary>
+
+We acknowledge the EuroHPC Joint Undertaking for awarding this project access to the EuroHPC
+supercomputer LUMI, hosted by CSC (Finland) and the LUMI consortium through a EuroHPC Regular
+Access call.
+
+This work was supported by European Union's Horizon Europe research and innovation programme
+under grant agreement number 101214398 (ELLIOT).
+
+Funded by the European Union. Views and opinions expressed are however those of the author(s)
+only and do not necessarily reflect those of the European Union or the European Commission.
+Neither the European Union nor the European Commission can be held responsible for them.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -655,8 +655,9 @@ Access call.
 This work was supported by European Union's Horizon Europe research and innovation programme
 under grant agreement number 101214398 (ELLIOT).
 
-Funded by the European Union. Views and opinions expressed are however those of the author(s)
-only and do not necessarily reflect those of the European Union or the European Commission.
-Neither the European Union nor the European Commission can be held responsible for them.
+**Disclaimer:** *Funded by the European Union. Views and opinions expressed are however those of
+the author(s) only and do not necessarily reflect those of the European Union or the European
+Commission. Neither the European Union nor the European Commission can be held responsible for
+them.*
 
 </details>


### PR DESCRIPTION
Adds a collapsible **Acknowledgements** block at the end of the Citation section, matching the README's existing `<details>` style. It mirrors the Acknowledgements appendix of the model report:

- EuroHPC Joint Undertaking / LUMI compute access
- Horizon Europe grant agreement 101214398 (ELLIOT)
- the EU funding disclaimer

Text only, same wording as the paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)